### PR TITLE
Add models for parsing content metadata from litezip models

### DIFF
--- a/press/models.py
+++ b/press/models.py
@@ -1,0 +1,10 @@
+from collections import namedtuple
+
+
+CollectionMetadata = namedtuple(
+    'CollectionMetadata',
+    ('id version created revised title '
+     'license_url language print_style '
+     'authors maintainers licensors '
+     'keywords subjects abstract')
+)

--- a/press/models.py
+++ b/press/models.py
@@ -1,10 +1,21 @@
 from collections import namedtuple
 
 
+__all__ = ('CollectionMetadata', 'ModuleMetadata',)
+
+
 CollectionMetadata = namedtuple(
     'CollectionMetadata',
     ('id version created revised title '
      'license_url language print_style '
+     'authors maintainers licensors '
+     'keywords subjects abstract')
+)
+
+ModuleMetadata = namedtuple(
+    'ModuleMetadata',
+    ('id version created revised title '
+     'license_url language '
      'authors maintainers licensors '
      'keywords subjects abstract')
 )

--- a/press/parsers/__init__.py
+++ b/press/parsers/__init__.py
@@ -1,1 +1,2 @@
 from .collection import parse_collection_metadata  # noqa: F401
+from .module import parse_module_metadata  # noqa: F401

--- a/press/parsers/__init__.py
+++ b/press/parsers/__init__.py
@@ -1,0 +1,1 @@
+from .collection import parse_collection_metadata  # noqa: F401

--- a/press/parsers/collection.py
+++ b/press/parsers/collection.py
@@ -1,0 +1,42 @@
+from functools import partial
+
+from lxml import etree
+from litezip.main import COLLECTION_NSMAP
+
+from press.models import CollectionMetadata
+
+
+def parse_collection_metadata(model):
+    """Given a Collection (``litezip.Collection``), parse out the metadata.
+    Return a CollectionMetadata object (``press.models.CollectionMetadata``).
+
+    """
+    elm_tree = etree.parse(model.file.open())
+    xpath = partial(elm_tree.xpath, namespaces=COLLECTION_NSMAP)
+    role_xpath = lambda xp: tuple(xpath(xp)[0].split())  # noqa: E731
+
+    props = {
+        'id': xpath('//md:content-id/text()')[0],
+        'version': xpath('//md:version/text()')[0],
+        'created': xpath('//md:created/text()')[0],
+        'revised': xpath('//md:revised/text()')[0],
+        'title': xpath('//md:title/text()')[0],
+        'license_url': xpath('//md:license/@url')[0],
+        'language': xpath('//md:language/text()')[0],
+        'authors': role_xpath('//md:role[@type="author"]/text()'),
+        'maintainers': role_xpath('//md:role[@type="maintainer"]/text()'),
+        'licensors': role_xpath('//md:role[@type="licensor"]/text()'),
+        'keywords': tuple(xpath('//md:keywordlist/md:keyword/text()')),
+        'subjects': tuple(xpath('//md:subjectlist/md:subject/text()')),
+        'abstract': xpath('//md:abstract/text()')[0],
+    }
+    print_style = xpath('//col:param[@name="print-style"]/@value')
+    if not print_style or not print_style[0]:
+        props['print_style'] = None
+    else:
+        props['print_style'] = print_style[0]
+
+    # Note, Press does not parse or update user (aka "actor" in the xml)
+    # information. This should be done directly using the "legacy" software.
+
+    return CollectionMetadata(**props)

--- a/press/parsers/common.py
+++ b/press/parsers/common.py
@@ -1,0 +1,49 @@
+from functools import partial
+
+from lxml import etree
+from litezip.main import COLLECTION_NSMAP
+
+
+__all__ = (
+    'make_elm_tree',
+    'make_cnx_xpath',
+    'parse_common_properties',
+)
+
+
+def make_elm_tree(model):
+    """Makes an ElementTree from a litezip model (Collection or Module)."""
+    with model.file.open() as fb:
+        elm_tree = etree.parse(fb)
+    return elm_tree
+
+
+def make_cnx_xpath(elm_tree):
+    """Makes an xpath function that includes the CNX namespaces."""
+    return partial(elm_tree.xpath, namespaces=COLLECTION_NSMAP)
+
+
+def parse_common_properties(elm_tree):
+    """Given an ElementTree lookup the common and return the properties."""
+    xpath = make_cnx_xpath(elm_tree)
+    role_xpath = lambda xp: tuple(xpath(xp)[0].split())  # noqa: E731
+
+    props = {
+        'id': xpath('//md:content-id/text()')[0],
+        'version': xpath('//md:version/text()')[0],
+        'created': xpath('//md:created/text()')[0],
+        'revised': xpath('//md:revised/text()')[0],
+        'title': xpath('//md:title/text()')[0],
+        'license_url': xpath('//md:license/@url')[0],
+        'language': xpath('//md:language/text()')[0],
+        'authors': role_xpath('//md:role[@type="author"]/text()'),
+        'maintainers': role_xpath('//md:role[@type="maintainer"]/text()'),
+        'licensors': role_xpath('//md:role[@type="licensor"]/text()'),
+        'keywords': tuple(xpath('//md:keywordlist/md:keyword/text()')),
+        'subjects': tuple(xpath('//md:subjectlist/md:subject/text()')),
+        'abstract': xpath('//md:abstract/text()')[0],
+    }
+
+    # Note, Press does not parse or update user (aka "actor" in the xml)
+    # information. This should be done directly using the "legacy" software.
+    return props

--- a/press/parsers/module.py
+++ b/press/parsers/module.py
@@ -1,0 +1,37 @@
+from functools import partial
+
+from lxml import etree
+from litezip.main import COLLECTION_NSMAP
+
+from press.models import ModuleMetadata
+
+
+def parse_module_metadata(model):
+    """Given a Module (``litezip.Module``), parse out the metadata.
+    Return a ModuleMetadata object (``press.models.ModuleMetadata``).
+
+    """
+    elm_tree = etree.parse(model.file.open())
+    xpath = partial(elm_tree.xpath, namespaces=COLLECTION_NSMAP)
+    role_xpath = lambda xp: tuple(xpath(xp)[0].split())  # noqa: E731
+
+    props = {
+        'id': xpath('//md:content-id/text()')[0],
+        'version': xpath('//md:version/text()')[0],
+        'created': xpath('//md:created/text()')[0],
+        'revised': xpath('//md:revised/text()')[0],
+        'title': xpath('//md:title/text()')[0],
+        'license_url': xpath('//md:license/@url')[0],
+        'language': xpath('//md:language/text()')[0],
+        'authors': role_xpath('//md:role[@type="author"]/text()'),
+        'maintainers': role_xpath('//md:role[@type="maintainer"]/text()'),
+        'licensors': role_xpath('//md:role[@type="licensor"]/text()'),
+        'keywords': tuple(xpath('//md:keywordlist/md:keyword/text()')),
+        'subjects': tuple(xpath('//md:subjectlist/md:subject/text()')),
+        'abstract': xpath('//md:abstract/text()')[0],
+    }
+
+    # Note, Press does not parse or update user (aka "actor" in the xml)
+    # information. This should be done directly using the "legacy" software.
+
+    return ModuleMetadata(**props)

--- a/press/parsers/module.py
+++ b/press/parsers/module.py
@@ -1,9 +1,5 @@
-from functools import partial
-
-from lxml import etree
-from litezip.main import COLLECTION_NSMAP
-
 from press.models import ModuleMetadata
+from .common import make_elm_tree, parse_common_properties
 
 
 def parse_module_metadata(model):
@@ -11,27 +7,4 @@ def parse_module_metadata(model):
     Return a ModuleMetadata object (``press.models.ModuleMetadata``).
 
     """
-    elm_tree = etree.parse(model.file.open())
-    xpath = partial(elm_tree.xpath, namespaces=COLLECTION_NSMAP)
-    role_xpath = lambda xp: tuple(xpath(xp)[0].split())  # noqa: E731
-
-    props = {
-        'id': xpath('//md:content-id/text()')[0],
-        'version': xpath('//md:version/text()')[0],
-        'created': xpath('//md:created/text()')[0],
-        'revised': xpath('//md:revised/text()')[0],
-        'title': xpath('//md:title/text()')[0],
-        'license_url': xpath('//md:license/@url')[0],
-        'language': xpath('//md:language/text()')[0],
-        'authors': role_xpath('//md:role[@type="author"]/text()'),
-        'maintainers': role_xpath('//md:role[@type="maintainer"]/text()'),
-        'licensors': role_xpath('//md:role[@type="licensor"]/text()'),
-        'keywords': tuple(xpath('//md:keywordlist/md:keyword/text()')),
-        'subjects': tuple(xpath('//md:subjectlist/md:subject/text()')),
-        'abstract': xpath('//md:abstract/text()')[0],
-    }
-
-    # Note, Press does not parse or update user (aka "actor" in the xml)
-    # information. This should be done directly using the "legacy" software.
-
-    return ModuleMetadata(**props)
+    return ModuleMetadata(**parse_common_properties(make_elm_tree(model)))

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,2 +1,5 @@
 # The project's dependencies...
+
+cnx-litezip==1.3.0
+
 pyramid==1.9.1

--- a/tests/unit/parsers/test_collection.py
+++ b/tests/unit/parsers/test_collection.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from litezip import parse_collection
+from litezip.main import COLLECTION_NSMAP
+from lxml import etree
+
+from press.parsers import parse_collection_metadata
+
+
+def test_parse_collection_metadata(litezip_valid_litezip):
+    # given a Collection object,
+    model = parse_collection(litezip_valid_litezip)
+    # parse the metadata into a CollectionMetadata,
+    md = parse_collection_metadata(model)
+    # which we then test for data point information
+
+    assert md.id == 'col11405'
+    assert md.version == '1.2'
+    assert md.created == '2011/05/24 10:31:56.888 GMT-5'
+    assert md.revised == '2013/03/11 22:52:33.244 GMT-5'
+    assert md.title == 'Intro to Computational Engineering: Elec 220 Labs'
+    assert md.license_url == 'http://creativecommons.org/licenses/by/3.0/'
+    assert md.language == 'en'
+
+    assert md.authors == ('mwjhnsn', 'jedifan42')
+    assert md.maintainers == ('mwjhnsn', 'jedifan42', 'cavallar')
+    assert md.licensors == ('mwjhnsn', 'jedifan42', 'cavallar')
+
+    assert md.keywords == (
+        'Calculator',
+        'Cavallaro',
+        'Elec 220',
+        'Gate',
+        'Interrupt',
+        'LC-3',
+        'Loop',
+        'Microcontroller',
+        'MSP 430',
+        'Rice',
+    )
+    assert md.subjects == ('Science and Technology',)
+
+    assert md.abstract == ("This collection houses all the documentation "
+                           "for the lab component of Rice Universities Elec "
+                           "220 lab component.  The labs cover topics such "
+                           "as gates, simulation, basic digital I/O, "
+                           "interrupt driven embedded programming, C "
+                           "language programming, and finally a/d "
+                           "interfacing and touch sensors.")
+    # This test case uses ``value=""`` in the xml, so a value is found.
+    assert md.print_style is None
+
+
+def test_parse_colletion_metdata_without_print_style(tmpdir,
+                                                     litezip_valid_litezip):
+    working_dir = tmpdir.mkdir('col')
+    collection_file = working_dir.join('collection.xml')
+    # Copy over and modify the collection.xml file.
+    with (litezip_valid_litezip / 'collection.xml').open() as origin:
+        xml = etree.parse(origin)
+        elm = xml.xpath('//col:param[@name="print-style"]',
+                        namespaces=COLLECTION_NSMAP)[0]
+        elm.getparent().remove(elm)
+        collection_file.write(etree.tostring(xml))
+    assert 'print-style' not in collection_file.read()
+
+    # Test the parser doesn't error when a print-style is missing.
+    # given a Collection object,
+    model = parse_collection(Path(working_dir))
+    # parse the metadata into a CollectionMetadata,
+    md = parse_collection_metadata(model)
+    assert md.print_style is None
+
+
+def test_parse_colletion_metdata_with_print_style(tmpdir,
+                                                  litezip_valid_litezip):
+    specific_print_style = 'woodblock'
+
+    working_dir = tmpdir.mkdir('col')
+    collection_file = working_dir.join('collection.xml')
+    # Copy over and modify the collection.xml file.
+    with (litezip_valid_litezip / 'collection.xml').open() as origin:
+        xml = etree.parse(origin)
+        elm = xml.xpath('//col:param[@name="print-style"]',
+                        namespaces=COLLECTION_NSMAP)[0]
+        elm.attrib['value'] = specific_print_style
+        collection_file.write(etree.tostring(xml))
+
+    # Test the parser doesn't error when a print-style is missing.
+    # given a Collection object,
+    model = parse_collection(Path(working_dir))
+    # parse the metadata into a CollectionMetadata,
+    md = parse_collection_metadata(model)
+    assert md.print_style == specific_print_style

--- a/tests/unit/parsers/test_module.py
+++ b/tests/unit/parsers/test_module.py
@@ -1,0 +1,36 @@
+from litezip import parse_module
+from press.parsers import parse_module_metadata
+
+
+def test_parse_module_metadata(litezip_valid_litezip):
+    module_id = 'm37154'
+    # given a Module object,
+    model = parse_module(litezip_valid_litezip / module_id)
+    # parse the metadata into a CollectionMetadata,
+    md = parse_module_metadata(model)
+    # which we then test for data point information
+
+    assert md.id == module_id
+    assert md.version == '1.2'
+    assert md.created == '2010/08/09 14:25:38 -0500'
+    assert md.revised == '2011/03/08 18:15:08 -0600'
+    assert md.title == ('A Student to Student Intro to IDE Programming '
+                        'and CCS4')
+    assert md.license_url == 'http://creativecommons.org/licenses/by/3.0/'
+    assert md.language == 'en'
+
+    assert md.authors == ('mwjhnsn', 'ww2')
+    assert md.maintainers == ('mwjhnsn', 'ww2')
+    assert md.licensors == ('mwjhnsn', 'ww2')
+
+    assert md.keywords == (
+        'CCSv4',
+        'Code Composer Studio',
+        'ELEC 220',
+        'IDE',
+        'MSP 430',
+    )
+    assert md.subjects == ('Science and Technology',)
+
+    assert md.abstract == ("A basic introduction to how to write "
+                           "and debug programs in Code Composer Studio V4.")


### PR DESCRIPTION
This work enables us to extract metadata information from the litezip models, which are simple wrapping models that represent the structural file elements that make up the content.