### PR TITLE
 Add a function for publishing a legacy module/page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
   - docker
 
 before_install:
+  # Stop the local postgres service
+  - sudo service postgresql stop
   # Install python3 venv to enable the linting venv
   - sudo apt-get install python3.4-venv
   # Create the virtual env and lint the codebase

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN set -x \
     && apt-get update \
     && apt-get install inotify-tools build-essential --no-install-recommends -y
 
+# Needed for testing
+RUN set -x \
+    && apt-get update \
+    && apt-get install wamerican --no-install-recommends -y
+
 COPY requirements /tmp/requirements
 
 # Install Python Dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,22 @@ services:
       - ./var:/app/var:z
     environment:
       - SHARED_DIR=/app/var
+  db:
+    image: openstax/cnx-db:1.4.0
+    ports:
+      - "5432:5432"
+    environment:
+      - DB_URL=postgresql://rhaptos@/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@/repository
   web:
     extends:
       service: app
     command: gunicorn -b 0.0.0.0:6543 -n press --reload wsgi:app
     ports:
       - "80:6543"
+    links:
+      - db
+    environment:
+      - SHARED_DIR=/app/var
+      - DB_URL=postgresql://rhaptos@db/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@db/repository

--- a/press/config.py
+++ b/press/config.py
@@ -29,6 +29,7 @@ def configure(settings=None):
     config = Configurator(settings=settings)
     config.include('.views')
 
+    config.include('cnxdb.contrib.pyramid')
     config.scan()
     return config
 

--- a/press/legacy_publishing.py
+++ b/press/legacy_publishing.py
@@ -1,0 +1,27 @@
+
+
+
+def publish_litezip(struct, registry):
+    """\
+    ``struct`` is a litezip struct from ``parse_litezip``
+    ``registry`` is a pyramid component architecture registry
+
+    """
+
+
+def publish_legacy_page(model, metadata, registry):
+    """\
+    ``model`` is a ``litezip.Module``
+    ``metadata`` is a ``ModuleMetadata``
+    ``registry`` is a pyramid component architecture registry
+
+    """
+
+
+def publish_legacy_book(model, metadata, registry):
+    """\
+    ``model`` is a ``litezip.Collection``
+    ``metadata`` is a ``CollectionMetadata``
+    ``registry`` is a pyramid component architecture registry
+
+    """

--- a/press/legacy_publishing.py
+++ b/press/legacy_publishing.py
@@ -1,4 +1,6 @@
-
+from litezip.main import COLLECTION_NSMAP
+from lxml import etree
+from sqlalchemy.sql import text
 
 
 def publish_litezip(struct, registry):
@@ -9,13 +11,108 @@ def publish_litezip(struct, registry):
     """
 
 
-def publish_legacy_page(model, metadata, registry):
+def publish_legacy_page(model, metadata, submission, registry):
     """\
     ``model`` is a ``litezip.Module``
     ``metadata`` is a ``ModuleMetadata``
+    ``submission`` is a two value tuple containing a userid and submit message
     ``registry`` is a pyramid component architecture registry
 
     """
+    engine = registry.engines['common']
+    t = registry.tables
+
+    if model.id is None or metadata.id is None:  # pragma: no cover
+        raise NotImplementedError()
+
+    with engine.begin() as trans:
+        result = trans.execute(
+            t.latest_modules.select()
+            .where(t.latest_modules.c.moduleid == metadata.id))
+        # At this time, this code assumes an existing module
+        existing_module = result.fetchone()
+        version = tuple(int(x) for x in existing_module.version.split('.'))
+        version = '.'.join([str(version[0]), str(version[1] + 1)])
+
+        # Insert module metadata
+        result = trans.execute(t.abstracts.insert()
+                               .values(abstract=metadata.abstract))
+        abstractid = result.inserted_primary_key[0]
+        result = trans.execute(
+            t.licenses.select()
+            .where(t.licenses.c.url == metadata.license_url))
+        licenseid = result.fetchone().licenseid
+        result = trans.execute(t.modules.insert().values(
+            moduleid=metadata.id,
+            version=version,
+            portal_type='Module',
+            name=metadata.title,
+            created=metadata.created,
+            revised=metadata.revised,
+            abstractid=abstractid,
+            licenseid=licenseid,
+            doctype='',
+            submitter=submission[0],
+            submitlog=submission[1],
+            language=metadata.language,
+            authors=metadata.authors,
+            maintainers=metadata.maintainers,
+            licensors=metadata.licensors,
+            # TODO metadata does not currently capture parentage
+            parent=None,
+            parentauthors=None,
+        ).returning(t.modules.c.module_ident, t.modules.c.moduleid))
+        ident, id = result.fetchone()
+
+        # Insert subjects metadata
+        stmt = (text('INSERT INTO moduletags '
+                     'SELECT :module_ident AS module_ident, tagid '
+                     'FROM tags WHERE tag = any(:subjects)')
+                .bindparams(module_ident=ident,
+                            subjects=list(metadata.subjects)))
+        result = trans.execute(stmt)
+
+        # Insert keywords metadata
+        stmt = (text('INSERT INTO keywords (word) '
+                     'SELECT iword AS word '
+                     'FROM unnest(:keywords ::text[]) AS iword '
+                     '     LEFT JOIN keywords AS kw ON (kw.word = iword) '
+                     'WHERE kw.keywordid IS NULL')
+                .bindparams(keywords=list(metadata.keywords)))
+        trans.execute(stmt)
+        stmt = (text('INSERT INTO modulekeywords '
+                     'SELECT :module_ident AS module_ident, keywordid '
+                     'FROM keywords WHERE word = any(:keywords)')
+                .bindparams(module_ident=ident,
+                            keywords=list(metadata.keywords)))
+        trans.execute(stmt)
+
+        # Rewrite the content with the id and version
+        with model.file.open('rb') as fb:
+            xml = etree.parse(fb)
+        elm = xml.xpath('//md:content-id', namespaces=COLLECTION_NSMAP)[0]
+        elm.text = id
+        elm = xml.xpath('//md:version', namespaces=COLLECTION_NSMAP)[0]
+        elm.text = version
+        with model.file.open('wb') as fb:
+            fb.write(etree.tostring(xml))
+
+        # Insert module files (content and resources)
+        with model.file.open('rb') as fb:
+            result = trans.execute(t.files.insert().values(
+                file=fb.read(),
+                media_type='text/xml',
+            ))
+        fileid = result.inserted_primary_key[0]
+        result = trans.execute(t.module_files.insert().values(
+            module_ident=ident,
+            fileid=fileid,
+            filename='index.cnxml',
+        ))
+
+        # TODO Insert resource files (images, pdfs, etc.)
+
+    return ident
 
 
 def publish_legacy_book(model, metadata, registry):

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,5 +1,9 @@
 # The project's dependencies...
 
+# If this pinning changes, remember to also change the pinning of the
+# cnx-db docker container image.
+cnx-db==1.4.0
+
 cnx-litezip==1.3.0
 
 pyramid==1.9.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,5 @@
 jinja2==2.10
 pytest==3.3.2
 pytest-cov==2.5.1
+python-dateutil==2.6.1
 WebTest >= 1.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 # The project's testing dependencies...
+jinja2==2.10
 pytest==3.3.2
 pytest-cov==2.5.1
 WebTest >= 1.3.1

--- a/tests/_templates/module.xml
+++ b/tests/_templates/module.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:bib="http://bibtexml.sf.net/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:q="http://cnx.rice.edu/qml/1.0" id="new" cnxml-version="0.7" module-id="new">
+
+<title>{{ metadata.title }}</title>
+<metadata xmlns:md="http://cnx.rice.edu/mdml"
+          mdml-version="0.5">
+  <md:repository>http://cnx.org/content</md:repository>
+  <md:content-url>http://cnx.org/content/m_____/latest</md:content-url>
+  <md:content-id>{{ metadata.id and metadata.id or '' }}</md:content-id>
+  <md:title>{{ metadata.title }}</md:title>
+  <md:version>{{ metadata.version }}</md:version>
+  <md:created>{{ metadata.created }}</md:created>
+  <md:revised>{{ metadata.revised }}</md:revised>
+  <md:actors>
+    {# Currently these values are ignored #}
+  </md:actors>
+  <md:roles>
+    <md:role type="author">{% for r in metadata.authors -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
+    <md:role type="maintainer">{% for r in metadata.maintainers -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
+    <md:role type="licensor">{% for r in metadata.licensors -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
+  </md:roles>
+  <md:license url="{{ metadata.license_url }}" />
+  <md:keywordlist>
+    {%- for keyword in metadata.keywords %}
+    <md:keyword>{{ keyword }}</md:keyword>
+    {%- endfor %}
+  </md:keywordlist>
+  <md:subjectlist>
+    {%- for subject in metadata.subjects %}
+    <md:subject>{{ subject }}</md:subject>
+    {%- endfor %}
+  </md:subjectlist>
+  <md:abstract>{{ metadata.abstract }}</md:abstract>
+  <md:language>en</md:language>
+</metadata>
+
+<content>
+
+{# TODO Update this resource stanza when resources are actually being used #}
+{#      In the mean time this is just a place holder #}
+{% for resource in resources -%}
+<figure id="">
+  <title>...</title>
+  <media id="eip-id#####" alt="...">
+    <image mime-type="image/png" src="filename-here.png"/>
+  </media>
+</figure>
+{%- endfor %}
+
+<para id="eip-254">This is a test document created for passing tests.</para>
+
+{% if terms %}
+<para id="eip-128">{{ terms }}</para>
+{% endif %}
+
+</content>
+</document>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,18 @@
 import os
 import pathlib
+import random
 import shutil
 import tempfile
 
+import jinja2
 import pytest
+from litezip import Module
 from pyramid.settings import asbool
+
+
+TEMPLATE_DIR = pathlib.Path(__file__).parent / '_templates'
+with (TEMPLATE_DIR / 'module.xml').open('r') as fb:
+    MODULE_DOC = fb.read()
 
 
 def _maybe_set(env_var, value):
@@ -44,3 +52,173 @@ def env_vars(keep_shared_directory):
             else:
                 f.unlink()
     shutil.rmtree(temp_shared_directory)
+
+
+PERSONS = (
+    # personid, firstname, surname, fullname, email
+    ['user1', 'User', 'One', 'User One', 'user1@example.com'],
+    ['user2', 'User', 'Two', 'User Duo', 'user2@example.com'],
+    ['user3', 'User', 'Three', 'Usuario Tres', 'user3@example.com'],
+    ['user4', 'User', 'Four', 'User IIII', 'user4@example.com'],
+)
+
+
+SUBJECTS = (
+    'Arts',
+    'Business',
+    'Humanities',
+    'Mathematics and Statistics',
+    'Science and Technology',
+    'Social Sciences',
+)
+
+
+@pytest.fixture(scope='session')
+def db_tables_session_scope(db_engines):
+    from cnxdb.contrib.pytest import db_tables
+    return db_tables(db_engines)
+
+
+@pytest.fixture
+def db_tables(db_tables_session_scope):
+    # override cnx-db's db_tables to use the session scoped version.
+    return db_tables_session_scope
+
+
+@pytest.fixture(scope='session', autouse=True)
+def testing(db_engines, db_tables_session_scope):
+    """This fixture clears all the tables prior to any test run.
+    Additionally, it minimally sets up database content. This content
+    is of the type that would not typically be handed by this application.
+
+    """
+    tables = (
+        'trees',
+        'modulecounts',
+        'modulekeywords',
+        'similarities',
+        'modulefti',
+        'module_files',
+        'collated_fti',
+        'moduletags',
+        'moduleoptionalroles',
+        'moduleratings',
+        'document_baking_result_associations',
+        'collated_file_associations',
+        'modules',
+        'latest_modules',
+        'abstracts',
+        'keywords',
+        'files',
+        'users',
+        'overall_hit_ranks',
+        'recent_hit_ranks',
+        'persons',
+        'print_style_recipes',
+        'default_print_style_recipes',
+        'document_hits',
+        'service_state_messages',
+        'publications',
+        'role_acceptances',
+        'license_acceptances',
+        'document_acl',
+        'pending_resource_associations',
+        'pending_documents',
+        'pending_resources',
+        'api_keys',
+        'document_controls',
+    )
+    # Clear out the tables
+    t = db_tables_session_scope
+    for table in tables:
+        stmt = getattr(t, table).delete()
+        db_engines['common'].execute(stmt)
+
+    # Insert 'persons', because this application doesn't do people.
+    # You either have a user before publishing or some other means of
+    # creating a user exists.
+    column_names = ['personid', 'firstname', 'surname', 'fullname', 'email']
+    db_engines['common'].execute(
+        t.persons.insert(),
+        [dict(zip(column_names, x)) for x in PERSONS])
+
+
+class _ContentUtil:
+
+    _word_catalog_filepath = '/usr/share/dict/words'
+    _persons = PERSONS
+    _subjects = SUBJECTS
+
+    def __init__(self):
+        with open(self._word_catalog_filepath, 'r') as fb:
+            word_catalog = list([x for x in fb.read().splitlines()
+                                 if len(x) >= 3 and "'" not in x])
+        self.word_catalog = word_catalog
+        self._created_dirs = []
+
+    def _clean_up(self):
+        for dir in self._created_dirs:
+            shutil.rmtree(str(dir))
+
+    def _mkdir(self):
+        dir = pathlib.Path(tempfile.mkdtemp())
+        self._created_dirs.append(dir)
+        return dir
+
+    def _rand_id_num(self):
+        return random.randint(10000, 99999)
+
+    def randword(self):
+        return random.choice(self.word_catalog)
+
+    def randperson(self):
+        return random.choice(self._persons)
+
+    def randsubj(self):
+        return random.choice(self._subjects)
+
+    def rand_module_id(self):
+        return 'm{}'.format(self._rand_id_num)
+
+    def gen_module_metadata(self, id=None):
+        return {
+            'id': id,
+            'version': '1.1',
+            'created': '2010/12/15 10:58:00 -0600',
+            'revised': '2011/08/16 13:55:25 -0500',
+            'title': ' '.join([self.randword(),
+                               self.randword(),
+                               self.randword()]),
+            'license_url': 'http://creativecommons.org/licenses/by-nc-sa/4.0/',
+            'language': 'en',
+            'authors': set([self.randperson()[0],
+                            self.randperson()[0]]),
+            'maintainers': set([self.randperson()[0],
+                                self.randperson()[0]]),
+            'licensors': [self.randperson()[0]],
+            'keywords': [self.randword()
+                         for x in range(1, random.randint(1, 5))],
+            'subjects': [self.randsubj()],
+            'abstract': 'testing abstract',
+        }
+
+    def gen_cnxml(self, metadata, resources, terms=[]):
+        template = jinja2.Template(MODULE_DOC)
+        return template.render(metadata=metadata, resources=resources,
+                               terms=' '.join(terms))
+
+    def gen_module(self, resources=[]):
+        id = None
+        module_dir = self._mkdir()
+        module_filepath = module_dir / 'm_____.cnxml'
+        metadata = self.gen_module_metadata(id=id)
+        with module_filepath.open('w') as fb:
+            fb.write(self.gen_cnxml(metadata, resources))
+        return Module(id, pathlib.Path(module_filepath), resources)
+
+
+@pytest.fixture(scope='session')
+def content_util(request):
+    util = _ContentUtil()
+    request.addfinalizer(util._clean_up)
+    return util

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import tempfile
 
 import pytest
 from pyramid.settings import asbool
-from webtest import TestApp
 
 
 def _maybe_set(env_var, value):
@@ -45,11 +44,3 @@ def env_vars(keep_shared_directory):
             else:
                 f.unlink()
     shutil.rmtree(temp_shared_directory)
-
-
-@pytest.fixture
-def webapp(env_vars):
-    """Creates a WebTest application for functional testing."""
-    from press.main import make_wsgi_app
-    app = make_wsgi_app()
-    return TestApp(app)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from webtest import TestApp
+
+
+@pytest.fixture
+def webapp(env_vars):
+    """Creates a WebTest application for functional testing."""
+    from press.main import make_wsgi_app
+    app = make_wsgi_app()
+    return TestApp(app)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from pyramid import testing as pyramid_testing
+
+
+@pytest.fixture
+def app(env_vars):
+    from press.config import configure
+    yield configure()
+    pyramid_testing.tearDown()

--- a/tests/unit/test_legacy_publishing.py
+++ b/tests/unit/test_legacy_publishing.py
@@ -1,3 +1,5 @@
+from dateutil.parser import parse as parse_date
+
 from press.legacy_publishing import (
     publish_legacy_book,
     publish_legacy_page,
@@ -5,13 +7,71 @@ from press.legacy_publishing import (
 )
 
 
-# def test_publish_new_legacy_page(db_engines, db_tables):
-#     pass
+def test_publish_revision_to_legacy_page(
+        content_util, persist_util, app, db_engines, db_tables):
+    module = content_util.gen_module()
+    module = persist_util.insert_module(module)
+
+    from press.parsers.module import parse_module_metadata
+    metadata = parse_module_metadata(module)
+
+    registry = app.registry
+    ident = publish_legacy_page(module, metadata,
+                                ('user1', 'test publish',),
+                                registry)
+
+    # Check core metadata insertion
+    stmt = (db_tables.modules.join(db_tables.abstracts)
+            .select()
+            .where(db_tables.modules.c.module_ident == ident))
+    result = db_engines['common'].execute(stmt).fetchone()
+    assert result.version == '1.2'
+    assert result.abstract == metadata.abstract
+    assert result.created == parse_date(metadata.created)
+    assert result.revised == parse_date(metadata.revised)
+    assert result.portal_type == 'Module'
+    assert result.name == metadata.title
+    assert result.licenseid == 13
+    assert result.submitter == 'user1'
+    assert result.submitlog == 'test publish'
+    assert result.authors == list(metadata.authors)
+    assert result.maintainers == list(metadata.maintainers)
+    assert result.licensors == list(metadata.licensors)
+
+    # Check subject metadata insertion
+    stmt = (db_tables.moduletags.join(db_tables.tags)
+            .select()
+            .where(db_tables.moduletags.c.module_ident == ident))
+    results = db_engines['common'].execute(stmt)
+    subjects = [x.tag for x in results]
+    assert sorted(subjects) == sorted(metadata.subjects)
+
+    # Check keyword metadata insertion
+    stmt = (db_tables.modulekeywords.join(db_tables.keywords)
+            .select()
+            .where(db_tables.modulekeywords.c.module_ident == ident))
+    results = db_engines['common'].execute(stmt)
+    keywords = [x.word for x in results]
+    assert sorted(keywords) == sorted(metadata.keywords)
+
+    # Check for file insertion
+    stmt = (db_tables.module_files
+            .join(db_tables.files)
+            .select()
+            .where(db_tables.module_files.c.module_ident == ident))
+    result = db_engines['common'].execute(stmt).fetchall()
+    filenames = [x.filename for x in result]
+    assert 'index.cnxml' in filenames
+    assert 'index.cnxml.html' in filenames
+
+    # TODO Check for resource file insertion
 
 
-# def test_publish_legacy_book(db_engines, db_tables):
-#     pass
+def test_publish_legacy_book(db_engines, db_tables):
+    publish_legacy_book
+    pass
 
 
-# def test_publish_litezip(db_engines, db_tables):
-#     pass
+def test_publish_litezip(db_engines, db_tables):
+    publish_litezip
+    pass

--- a/tests/unit/test_legacy_publishing.py
+++ b/tests/unit/test_legacy_publishing.py
@@ -1,0 +1,17 @@
+from press.legacy_publishing import (
+    publish_legacy_book,
+    publish_legacy_page,
+    publish_litezip,
+)
+
+
+# def test_publish_new_legacy_page(db_engines, db_tables):
+#     pass
+
+
+# def test_publish_legacy_book(db_engines, db_tables):
+#     pass
+
+
+# def test_publish_litezip(db_engines, db_tables):
+#     pass


### PR DESCRIPTION
This only publishes the metadata and content files for a module (aka page).
A future feature will address the publication of resource files.

These changes also contains the addition of cnx-db the library and container. These are used to provide database connectivity and services.

Other elements in these changes include two testing utilities used to aid in the creation and persistence of testing content.