### PR TITLE
 Add a function for publishing a legacy collection/book

### DIFF
--- a/press/legacy_publishing.py
+++ b/press/legacy_publishing.py
@@ -115,10 +115,107 @@ def publish_legacy_page(model, metadata, submission, registry):
     return ident
 
 
-def publish_legacy_book(model, metadata, registry):
+def publish_legacy_book(model, metadata, submission, registry):
     """\
     ``model`` is a ``litezip.Collection``
     ``metadata`` is a ``CollectionMetadata``
+    ``submission`` is a two value tuple containing a userid and submit message
     ``registry`` is a pyramid component architecture registry
 
     """
+    engine = registry.engines['common']
+    t = registry.tables
+
+    if model.id is None or metadata.id is None:  # pragma: no cover
+        raise NotImplementedError()
+
+    with engine.begin() as trans:
+        result = trans.execute(
+            t.modules.select()
+            .where(t.modules.c.moduleid == metadata.id)
+            .order_by(t.modules.c.major_version.desc())
+            .limit(1))
+        # At this time, this code assumes an existing module
+        existing_module = result.fetchone()
+        version = tuple(int(x) for x in existing_module.version.split('.'))
+        version = '.'.join([str(version[0]), str(version[1] + 1)])
+
+        # Insert module metadata
+        result = trans.execute(t.abstracts.insert()
+                               .values(abstract=metadata.abstract))
+        abstractid = result.inserted_primary_key[0]
+        result = trans.execute(
+            t.licenses.select()
+            .where(t.licenses.c.url == metadata.license_url))
+        licenseid = result.fetchone().licenseid
+        result = trans.execute(t.modules.insert().values(
+            moduleid=metadata.id,
+            version=version,
+            portal_type='Collection',
+            name=metadata.title,
+            created=metadata.created,
+            revised=metadata.revised,
+            abstractid=abstractid,
+            licenseid=licenseid,
+            doctype='',
+            submitter=submission[0],
+            submitlog=submission[1],
+            language=metadata.language,
+            authors=metadata.authors,
+            maintainers=metadata.maintainers,
+            licensors=metadata.licensors,
+            # TODO metadata does not currently capture parentage
+            parent=None,
+            parentauthors=None,
+        ).returning(t.modules.c.module_ident, t.modules.c.moduleid))
+        ident, id = result.fetchone()
+
+        # Insert subjects metadata
+        stmt = (text('INSERT INTO moduletags '
+                     'SELECT :module_ident AS module_ident, tagid '
+                     'FROM tags WHERE tag = any(:subjects)')
+                .bindparams(module_ident=ident,
+                            subjects=list(metadata.subjects)))
+        result = trans.execute(stmt)
+
+        # Insert keywords metadata
+        stmt = (text('INSERT INTO keywords (word) '
+                     'SELECT iword AS word '
+                     'FROM unnest(:keywords ::text[]) AS iword '
+                     '     LEFT JOIN keywords AS kw ON (kw.word = iword) '
+                     'WHERE kw.keywordid IS NULL')
+                .bindparams(keywords=list(metadata.keywords)))
+        trans.execute(stmt)
+        stmt = (text('INSERT INTO modulekeywords '
+                     'SELECT :module_ident AS module_ident, keywordid '
+                     'FROM keywords WHERE word = any(:keywords)')
+                .bindparams(module_ident=ident,
+                            keywords=list(metadata.keywords)))
+        trans.execute(stmt)
+
+        # Rewrite the content with the id and version
+        with model.file.open('rb') as fb:
+            xml = etree.parse(fb)
+        elm = xml.xpath('//md:content-id', namespaces=COLLECTION_NSMAP)[0]
+        elm.text = id
+        elm = xml.xpath('//md:version', namespaces=COLLECTION_NSMAP)[0]
+        elm.text = version
+        with model.file.open('wb') as fb:
+            fb.write(etree.tostring(xml))
+
+        # Insert module files (content and resources)
+        with model.file.open('rb') as fb:
+            result = trans.execute(t.files.insert().values(
+                file=fb.read(),
+                media_type='text/xml',
+            ))
+        fileid = result.inserted_primary_key[0]
+        result = trans.execute(t.module_files.insert().values(
+            module_ident=ident,
+            fileid=fileid,
+            filename='collection.xml',
+        ))
+
+        # TODO Insert resource files (cover image, recipe, etc.)
+
+    return ident

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,4 +3,5 @@ jinja2==2.10
 pytest==3.3.2
 pytest-cov==2.5.1
 python-dateutil==2.6.1
+recordclass==0.5
 WebTest >= 1.3.1

--- a/tests/_templates/collection.xml
+++ b/tests/_templates/collection.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<col:collection xmlns="http://cnx.rice.edu/collxml"
+                xmlns:cnx="http://cnx.rice.edu/cnxml"
+                xmlns:cnxorg="http://cnx.rice.edu/system-info"
+                xmlns:md="http://cnx.rice.edu/mdml"
+                xmlns:col="http://cnx.rice.edu/collxml"
+                xmlns:cnxml="http://cnx.rice.edu/cnxml"
+                xmlns:m="http://www.w3.org/1998/Math/MathML"
+                xmlns:q="http://cnx.rice.edu/qml/1.0"
+                xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                xmlns:bib="http://bibtexml.sf.net/"
+                xmlns:cc="http://web.resource.org/cc/"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xml:lang="en">
+  <metadata xmlns:md="http://cnx.rice.edu/mdml"
+            mdml-version="0.5">
+    <md:repository>http://cnx.org/content</md:repository>
+    <md:content-url>http://cnx.org/content/m_____/latest</md:content-url>
+    <md:content-id>{{ metadata.id and metadata.id or '' }}</md:content-id>
+    <md:title>{{ metadata.title }}</md:title>
+    <md:version>{{ metadata.version }}</md:version>
+    <md:created>{{ metadata.created }}</md:created>
+    <md:revised>{{ metadata.revised }}</md:revised>
+    <md:actors>
+      {# Currently these values are ignored #}
+    </md:actors>
+    <md:roles>
+      <md:role type="author">{% for r in metadata.authors -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
+      <md:role type="maintainer">{% for r in metadata.maintainers -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
+      <md:role type="licensor">{% for r in metadata.licensors -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
+    </md:roles>
+    <md:license url="{{ metadata.license_url }}" />
+    <md:keywordlist>
+      {%- for keyword in metadata.keywords %}
+      <md:keyword>{{ keyword }}</md:keyword>
+      {%- endfor %}
+    </md:keywordlist>
+    <md:subjectlist>
+      {%- for subject in metadata.subjects %}
+      <md:subject>{{ subject }}</md:subject>
+      {%- endfor %}
+    </md:subjectlist>
+    <md:abstract>{{ metadata.abstract }}</md:abstract>
+    <md:language>en</md:language>
+  </metadata>
+
+  <col:parameters>
+    <col:param name="real-imaginary-notation" value="font"/>
+    <col:param name="and-or-notation"
+               value="propositional-logic"/>
+    <col:param name="gradient-notation" value="text"/>
+    <col:param name="mean-notation" value="bar"/>
+    <col:param name="remainder-notation" value="text"/>
+    <col:param name="conjugate-notation" value="bar"/>
+    <col:param name="imaginary-i-notation" value="i"/>
+    <col:param name="scalar-product-notation"
+               value="angle-bracket"/>
+    <col:param name="print-font-size" value="10pt"/>
+    <col:param name="curl-notation" value="text"/>
+    <col:param name="for-all-equation-layout"
+               value="symbolic"/>
+    <col:param name="vector-notation" value="bold"/>
+    <col:param name="print-paper-size" value="8.5x11"/>
+    <col:param name="print-font" value="computer-modern"/>
+    <col:param name="print-style" value="{{ metadata.print_style|default('') }}"/>
+    <col:param name="print-paragraph-spacing"
+               value="compact"/>
+  </col:parameters>
+
+  <col:content>
+    {# This assumes a single subcollection depth, because otherwise this template would need some type of 'block' setup, which would require a full jinja2 environment setup. Only take that approach if you absolutely must. #}
+
+    {% for item in tree %}
+      {% if item.contents %}
+        <col:subcollection>
+          <md:title>{{ item.title }}</md:title>
+          <col:content>
+            {% for sub_item in item.contents %}
+              <col:module document="{{ sub_item.id }}" version="{{ sub_item.version }}"
+                          repository="http://cnx.org/content"
+                          cnxorg:version-at-this-collection-version="{{ sub_item.version_at }}">
+                <md:title>{{ sub_item.title }}</md:title>
+              </col:module>
+            {% endfor %}
+          </col:content>
+        </col:subcollection>
+      {% else %}
+        <col:module document="{{ item.id }}" version="{{ item.version }}"
+                    repository="http://cnx.org/content"
+                    cnxorg:version-at-this-collection-version="{{ item.version_at }}">
+          <md:title>{{ item.title }}</md:title>
+        </col:module>
+      {% endif %}
+    {% endfor %}    
+  </col:content>
+</col:collection>

--- a/tests/unit/test_legacy_publishing.py
+++ b/tests/unit/test_legacy_publishing.py
@@ -1,9 +1,14 @@
 from dateutil.parser import parse as parse_date
+from sqlalchemy.sql import text
 
 from press.legacy_publishing import (
     publish_legacy_book,
     publish_legacy_page,
     publish_litezip,
+)
+from press.parsers import (
+    parse_collection_metadata,
+    parse_module_metadata,
 )
 
 
@@ -12,7 +17,6 @@ def test_publish_revision_to_legacy_page(
     module = content_util.gen_module()
     module = persist_util.insert_module(module)
 
-    from press.parsers.module import parse_module_metadata
     metadata = parse_module_metadata(module)
 
     registry = app.registry
@@ -67,9 +71,104 @@ def test_publish_revision_to_legacy_page(
     # TODO Check for resource file insertion
 
 
-def test_publish_legacy_book(db_engines, db_tables):
-    publish_legacy_book
-    pass
+def compare_tree_similarity(db_tree, test_tree):
+    """Compare the two types of tree, one coming from the database using
+    `tree_to_json_for_legacy` and the other using the tree structure
+    provided by the `content_util` testing utility.
+
+    """
+    for i, v in enumerate(db_tree):
+        if v['id'].startswith('col'):
+            assert test_tree[i].title == v['title']
+            compare_tree_similarity(v['contents'], test_tree[i].contents)
+        else:
+            node = test_tree[i]
+            assert v['id'] == node.id
+            assert v['title'] == node.title
+            assert v['version'] == node.version_at
+
+
+def test_publish_legacy_book(
+        content_util, persist_util, app, db_engines, db_tables):
+    # Insert initial collection and modules.
+    collection, tree, modules = content_util.gen_collection()
+    modules = list([persist_util.insert_module(m) for m in modules])
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    collection = persist_util.insert_collection(collection)
+    metadata = parse_collection_metadata(collection)
+
+    # Insert a new module ...
+    new_module = content_util.gen_module()
+    new_module = persist_util.insert_module(new_module)
+    # ... remove second element from the tree ...
+    tree.pop(1)
+    # ... and append the new module to the tree.
+    tree.append(content_util.make_tree_node_from(new_module))
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+
+    registry = app.registry
+    ident = publish_legacy_book(collection, metadata,
+                                ('user1', 'test publish',),
+                                registry)
+
+    # Check core metadata insertion
+    stmt = (db_tables.modules.join(db_tables.abstracts)
+            .select()
+            .where(db_tables.modules.c.module_ident == ident))
+    result = db_engines['common'].execute(stmt).fetchone()
+    assert result.version == '1.2'
+    assert result.abstract == metadata.abstract
+    assert result.created == parse_date(metadata.created)
+    assert result.revised == parse_date(metadata.revised)
+    assert result.portal_type == 'Collection'
+    assert result.name == metadata.title
+    assert result.licenseid == 13
+    assert result.submitter == 'user1'
+    assert result.submitlog == 'test publish'
+    assert result.authors == list(metadata.authors)
+    assert result.maintainers == list(metadata.maintainers)
+    assert result.licensors == list(metadata.licensors)
+
+    # Check subject metadata insertion
+    stmt = (db_tables.moduletags.join(db_tables.tags)
+            .select()
+            .where(db_tables.moduletags.c.module_ident == ident))
+    results = db_engines['common'].execute(stmt)
+    subjects = [x.tag for x in results]
+    assert sorted(subjects) == sorted(metadata.subjects)
+
+    # Check keyword metadata insertion
+    stmt = (db_tables.modulekeywords.join(db_tables.keywords)
+            .select()
+            .where(db_tables.modulekeywords.c.module_ident == ident))
+    results = db_engines['common'].execute(stmt)
+    keywords = [x.word for x in results]
+    assert sorted(keywords) == sorted(metadata.keywords)
+
+    # Check for file insertion
+    stmt = (db_tables.module_files
+            .join(db_tables.files)
+            .select()
+            .where(db_tables.module_files.c.module_ident == ident))
+    result = db_engines['common'].execute(stmt).fetchall()
+    filenames = [x.filename for x in result]
+    assert 'collection.xml' in filenames
+
+    # TODO Check for resource file insertion
+
+    # Check the tree for accuracy (even though this is out of scope)
+    stmt = (
+        text("SELECT tree_to_json_for_legacy("
+             "  m.uuid::text, "
+             "  concat_ws('.', m.major_version, m.minor_version)::text"
+             ")::json "
+             "FROM modules AS m "
+             "WHERE m.module_ident = :module_ident")
+        .bindparams(module_ident=ident))
+    inserted_tree = db_engines['common'].execute(stmt).fetchone()[0]
+    compare_tree_similarity(inserted_tree['contents'], tree)
 
 
 def test_publish_litezip(db_engines, db_tables):


### PR DESCRIPTION
This only publishes the metadata and collection.xml file for a collection (aka book).
A future feature will address the publication of resource files(e.g. cover image, recipe, etc.).

These changes also contain additions to the content and persist testing utilities to handle collection type data.