### PR TITLE
 Add a function for publishing litezip formatted content

### DIFF
--- a/tests/unit/test_legacy_publishing.py
+++ b/tests/unit/test_legacy_publishing.py
@@ -20,9 +20,9 @@ def test_publish_revision_to_legacy_page(
     metadata = parse_module_metadata(module)
 
     registry = app.registry
-    ident = publish_legacy_page(module, metadata,
-                                ('user1', 'test publish',),
-                                registry)
+    (id, version), ident = publish_legacy_page(module, metadata,
+                                               ('user1', 'test publish',),
+                                               registry)
 
     # Check core metadata insertion
     stmt = (db_tables.modules.join(db_tables.abstracts)
@@ -109,9 +109,9 @@ def test_publish_legacy_book(
                                                                 tree)
 
     registry = app.registry
-    ident = publish_legacy_book(collection, metadata,
-                                ('user1', 'test publish',),
-                                registry)
+    (id, version), ident = publish_legacy_book(collection, metadata,
+                                               ('user1', 'test publish',),
+                                               registry)
 
     # Check core metadata insertion
     stmt = (db_tables.modules.join(db_tables.abstracts)
@@ -171,6 +171,46 @@ def test_publish_legacy_book(
     compare_tree_similarity(inserted_tree['contents'], tree)
 
 
-def test_publish_litezip(db_engines, db_tables):
-    publish_litezip
-    pass
+def test_publish_litezip(
+        content_util, persist_util, app, db_engines, db_tables):
+    # Insert initial collection and modules.
+    collection, tree, modules = content_util.gen_collection()
+    modules = list([persist_util.insert_module(m) for m in modules])
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    collection = persist_util.insert_collection(collection)
+
+    # Insert a new module ...
+    new_module = content_util.gen_module(relative_to=collection)
+    new_module = persist_util.insert_module(new_module)
+    # ... remove second element from the tree ...
+    tree.pop(1)
+    # ... and append the new module to the tree.
+    tree.append(content_util.make_tree_node_from(new_module))
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    struct = tuple([collection, new_module])
+
+    registry = app.registry
+    id_map = publish_litezip(struct, ('user1', 'test publish',), registry)
+    expected_id_map = {
+        new_module.id: (new_module.id, '1.2'),
+        collection.id: (collection.id, '1.2'),
+    }
+    assert id_map == expected_id_map
+
+    # Update the tree to reflect the Module publication above.
+    tree[-1].version_at = '1.2'
+
+    # Check the collection tree for accuracy. (This is not out of scope,
+    # because the collection.xml document needs modified before insertion.)
+    stmt = (
+        text("SELECT tree_to_json_for_legacy("
+             "  m.uuid::text, "
+             "  concat_ws('.', m.major_version, m.minor_version)::text"
+             ")::json "
+             "FROM modules AS m "
+             "WHERE m.moduleid = :moduleid AND m.version = :version")
+        .bindparams(moduleid=collection.id, version='1.2'))
+    inserted_tree = db_engines['common'].execute(stmt).fetchone()[0]
+    compare_tree_similarity(inserted_tree['contents'], tree)


### PR DESCRIPTION
This publishes revisions to existing content in a bulk format (litezip).
At this time, the contents of the litezip structure are assumed to have
a collection and optionally have some modules.

These changes also include a way for the content testing utility to generate content relative to each other. That is, relative on the file system. For example, generating a collection with modules will now format the contents on the filesystem to be a litezip filesystem structure.