### PR TITLE
Add view to publish an uploaded litezip

### DIFF
--- a/press/publishing.py
+++ b/press/publishing.py
@@ -1,10 +1,12 @@
 import tempfile
+import zipfile
 from pathlib import Path
 
 from pyramid.threadlocal import get_current_registry
 
 
 __all__ = (
+    'expand_zip',
     'persist_file_to_filesystem',
 )
 
@@ -21,3 +23,21 @@ def persist_file_to_filesystem(file):
         fb.write(file.read())
     file.seek(0)
     return filepath
+
+
+def expand_zip(filepath):
+    settings = get_current_registry().settings
+    shared_directory = Path(settings['shared_directory'])
+    _names = tempfile._get_candidate_names()
+    while True:
+        dir = shared_directory / next(_names)
+        try:
+            dir.mkdir()
+        except FileExistsError:  # pragma: no cover
+            continue
+        break
+    expand_path = dir
+
+    with filepath.open('rb') as fb, zipfile.ZipFile(fb) as z:
+        z.extractall(path=str(expand_path))
+    return expand_path

--- a/press/views/__init__.py
+++ b/press/views/__init__.py
@@ -1,4 +1,19 @@
+from pathlib import Path
+
+
+here = Path(__file__).parent
+
+
 def includeme(config):
     """Declaration of routing"""
     add_route = config.add_route
     add_route('ping', '/ping')
+
+    s = config.registry.settings
+    s['pyramid_swagger.exclude_paths'] = [
+        '^/api-docs/?',
+        '^/ping/?',
+    ]
+    s['pyramid_swagger.schema_file'] = 'swagger.yaml'
+    s['pyramid_swagger.schema_directory'] = str(here / 'api-docs')
+    config.include('pyramid_swagger')

--- a/press/views/__init__.py
+++ b/press/views/__init__.py
@@ -9,6 +9,13 @@ def includeme(config):
     add_route = config.add_route
     add_route('ping', '/ping')
 
+    add_route('api.v1.versioned_content', '/content/{id}/{ver}')
+
+    add_route('api.v2.contents', '/contents/{ident_hash}')
+    add_route('api.v2.resources', '/resources/{hash}')
+
+    add_route('api.v3.publications', '/api/v3/publish')
+
     s = config.registry.settings
     s['pyramid_swagger.exclude_paths'] = [
         '^/api-docs/?',

--- a/press/views/api-docs/swagger.yaml
+++ b/press/views/api-docs/swagger.yaml
@@ -1,0 +1,830 @@
+swagger: '2.0'
+info:
+  description: >-
+    This server contains educational resources that can be accessed freely by
+    anyone.  You can find out more about OpenStax Connexions (CNX) at
+    [https://openstax.org](https://openstax.org).
+  version: 3.0.0
+  title: CNX API
+  termsOfService: 'http://cnx.org/api-docs/terms/'
+  contact:
+    email: api@cnx.org
+  license:
+    name: GNU AGPL
+    url: 'https://www.gnu.org/licenses/agpl.html'
+host: archive.cnx.org
+schemes:
+  - https
+tags:
+  # area tags
+  - name: content
+    description: >-
+      These provide access to content.
+  - name: resource
+    description: >-
+      These provide access to content resources.
+  - name: export
+    description: >-
+      These provide access to content exports.
+  - name: search
+    description: >-
+      These allow one to search for content.
+  - name: system
+    description: >-
+      These provide information about the system or application as a whole
+  # purpose tags
+  - name: redirect
+    description: >-
+      These are routes that only produce redirection
+  - name: convenience
+    description: >-
+      These are routes that are convenient for developer usage
+      from within the browser. As such, they do not have an operationId
+      because they are meant only for use within the browser
+      rather than as actual API usage.
+paths:
+  '/contents/{id}':
+    get:
+      summary: Retrieves content from the repository
+      description: ''
+      operationId: getContentById
+      produces:
+        - text/html
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to return
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: "#/definitions/ContentResponse"
+        '404':
+          description: Content not found
+      tags:
+        - content
+  '/contents/{id}.html':
+    get:
+      summary: Retrieves content from the repository as HTML
+      description: ''
+      produces:
+        - text/html
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to return
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+        '404':
+          description: Content not found
+      tags:
+        - convenience
+        - content
+  '/contents/{id}/{filename}.html':
+    get:
+      summary: Retrieves content from the repository as HTML
+      description: ''
+      produces:
+        - text/html
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to return
+          required: true
+          type: string
+        - name: filename
+          in: path
+          description: Optional filename for the content
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+        '404':
+          description: Content not found
+      tags:
+        - convenience
+        - content
+  '/contents/{id}.json':
+    get:
+      summary: Retrieves content from the repository
+      description: ''
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to return
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: "#/definitions/ContentResponse"
+        '404':
+          description: Content not found
+      tags:
+        - convenience
+        - content
+  '/contents/{id}/{filename}.json':
+    get:
+      summary: Retrieves content from the repository
+      description: ''
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to return
+          required: true
+          type: string
+        - name: filename
+          in: path
+          description: Optional filename for the content
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: "#/definitions/ContentResponse"
+        '404':
+          description: Content not found
+      tags:
+        - convenience
+        - content
+  '/resources/{id}':
+    get:
+      summary: Retrieves file resources
+      description: ''
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: id
+          in: path
+          description: ID of the resource (aka SHA)
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Resource not found
+      tags:
+        - resource
+  '/resources/{id}/{filename}':
+    get:
+      summary: Retrieves file resources
+      description: ''
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: id
+          in: path
+          description: ID of the resource (aka SHA)
+          required: true
+          type: string
+        - name: filename
+          in: path
+          description: optional filename of the resource
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Resource not found
+      tags:
+        - convenience
+        - resource
+  '/exports/{id}.{type}':
+    get:
+      summary: Retrieves a content export file for the requested type
+      description: ''
+      operationId: getExportByIdAndType
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to return
+          required: true
+          type: string
+        - name: type
+          in: path
+          description: The export file type
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: file
+        '404':
+          description: Resource not found
+      tags:
+        - export
+  '/exports/{id}.{type}/{filename}':
+    get:
+      summary: Retrieves a content export file for the requested type
+      description: ''
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to return
+          required: true
+          type: string
+        - name: type
+          in: path
+          description: The export file type
+          required: true
+          type: string
+        - name: filename
+          in: path
+          description: Optional filename for the content
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+        '404':
+          description: Resource not found
+      tags:
+        - convenience
+        - export
+  '/extras/{id}':
+    get:
+      summary: Retrieves extra information asociated with the content
+      description: ''
+      operationId: getExtraInfoById
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to return
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            properties:
+              isLatest:
+                type: boolean
+              downloads:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    created:
+                      type: string
+                      x-nullable: true
+                      example: "2014-07-16T09:36:37-05:00"
+                    format:
+                      type: string
+                      example: "PDF"
+                    filename:
+                      type: string
+                      example: "preface-fast-fourier-transforms-10.pdf"
+                    state:
+                      type: string
+                      enum:
+                        - "good"
+                        - "missing"
+                    details:
+                      type: string
+                    path:
+                      type: string
+                      description: URL path to the export file
+                      example: "/exports/fb55ec78-f907-4422-aa37-0d6b501b03b6@10.pdf/preface-fast-fourier-transforms-10.pdf"
+                    size:
+                      type: integer
+              state:
+                type: string
+              canPublish:
+                type: array
+                items:
+                  type: string
+              books:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    authors:
+                      type: array
+                      items:
+                        type: string
+                    ident_hash:
+                      type: string
+                    title:
+                      type: string
+        '404':
+          description: Content not found
+      tags:
+        - content
+  /search:
+    get:
+      summary: Search the repository for content
+      description: ''
+      operationId: search
+      produces:
+        - application/json
+      parameters:
+        - name: q
+          in: query
+          description: A space separated string of search terms
+          type: string
+        - name: t
+          in: query
+          description: The type of search operator to use between terms
+          type: string
+          enum:
+            - "OR"
+            - "AND"
+            - "weakAND"
+        - name: per_page
+          in: query
+          type: string
+          description: The number of results per page
+          type: string
+        - name: page
+          in: query
+          description: The page number for a sequence of results
+          type: string
+        - name: nocache
+          in: query
+          type: string
+          # FIXME Why does this check for the string 'true'?
+          enum:
+            - "true"
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            properties:
+              query:
+                type: object
+                properties:
+                  sort:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - "popularity"
+                        - "pubDate"
+                        - "version"
+                  per_page:
+                    type: integer
+                  page:
+                    type: integer
+                  limits:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        tag:
+                          type: string
+                        value:
+                          type: string
+                        index:
+                          type: integer
+              results:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        bodySnippet:
+                          type: string
+                          x-nullable: true
+                        summarySnippet:
+                          type: string
+                          x-nullable: true
+                        pubDate:
+                          type: string
+                          example: "2017-05-31T16:01:51Z"
+                        title:
+                          type: string
+                        keywords:
+                          type: array
+                          items:
+                            type: string
+                        authors:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                description: "The author's ID"
+                              index:
+                                type: integer
+                                description: "The index of where to find the author's full details in the root object's 'auxiliary' value."
+                        id:
+                          type: string
+                        mediaType:
+                          $ref: "#/definitions/MediaType"
+                  total:
+                    type: integer
+                  auxiliary:
+                    type: object
+                    properties:
+                      types:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              description: "media-type for this type"
+                            name:
+                              type: string
+                              description: "human readable name for this type"
+                      authors:
+                        $ref: "#/definitions/PersonList"
+                  limits:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        tag:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              count:
+                                type: integer
+                              index:
+                                type: integer
+                                description: "Only present when the value is an author ID"
+                              value:
+                                type: string
+      tags:
+        - search
+  '/search/{id}':
+    get:
+      summary: Search the repository for content
+      description: ''
+      operationId: searchInBook
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ID of content to search within
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+      tags:
+        - content
+        - search
+  /extras:
+    get:
+      summary: Retrieves extra information about the repository of content
+      description: ''
+      operationId: getExtras
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            properties:
+              featuredLinks:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    version:
+                      type: string
+                    legacy_id:
+                      type: string
+                    legacy_version:
+                      type: string
+                    title:
+                      type: string
+                    abstract:
+                      type: string
+                      x-nullable: true
+                    resourcePath:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                        - "CNX Featured"
+                        - "OpenStax Featured"
+              messages:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      x-nullable: true
+                    priority:
+                      type: integer
+                    message:
+                      type: string
+                    starts:
+                      type: string
+                    ends:
+                      type: string
+              licenses:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    url:
+                      type: string
+                    code:
+                      type: string
+                    name:
+                      type: string
+                    version:
+                      type: string
+                    isValidForPublication:
+                      type: boolean
+              subjects:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    count:
+                      type: object
+                      properties:
+                        # allow these to be null for dev apps
+                        collection:
+                          type: integer
+                          x-nullable: true
+                        module:
+                          type: integer
+                          x-nullable: true
+              # FIXME I'm not sure one can represent an array of array that is of mixed types.
+              # languages_and_count:
+              #   type: array
+      tags:
+        - system
+  '/content/{id}':
+    get:
+      summary: Retrieves content from the repository
+      deprecated: true
+      description: ''
+      parameters:
+        - name: id
+          in: path
+          description: legacy ID for content
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: "#/definitions/ContentResponse"
+        '404':
+          description: Not found
+      tags:
+        - content
+  '/content/{id}/{ver}':
+    get:
+      summary: Retrieves content from the repository
+      deprecated: true
+      description: ''
+      parameters:
+        - name: id
+          in: path
+          description: legacy ID for content
+          required: true
+          type: string
+        - name: ver
+          in: path
+          description: legacy version for content
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: "#/definitions/ContentResponse"
+        '404':
+          description: Not found
+      tags:
+        - content
+  '/content/{id}/{ver}/{filename}':
+    get:
+      summary: Retrieves a file from the repository
+      deprecated: true
+      description: ''
+      parameters:
+        - name: id
+          in: path
+          description: legacy ID for content
+          required: true
+          type: string
+        - name: ver
+          in: path
+          description: legacy version for content
+          required: true
+          type: string
+        - name: filename
+          in: path
+          description: Optional filename for the content
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: file
+        '404':
+          description: Not found
+      tags:
+        - content
+definitions:
+  MediaType:
+    type: string
+    enum:
+      - "application/vnd.org.cnx.module"
+      - "application/vnd.org.cnx.composite-module"
+      - "application/vnd.org.cnx.collection"
+      - "application/vnd.org.cnx.subcollection"
+      - "application/vnd.org.cnx.folder"
+  Person:
+    type: object
+    properties:
+      surname:
+        type: string
+      suffix:
+        type: string
+        x-nullable: true
+      firstname:
+        type: string
+      title:
+        type: string
+        x-nullable: true
+      fullname:
+        type: string
+      id:
+        type: string
+  PersonList:
+    type: array
+    items:
+      $ref: "#/definitions/Person"
+  ContentResponse:
+    type: object
+    properties:
+      googleAnalytics:
+        type: string
+        example: "UA-10730853-18"
+      version:
+        type: string
+      submitlog:
+        type: string
+      abstract:
+        type: string
+      revised:
+        type: string
+      printStyle:
+        type: string
+        x-nullable: true
+      # FIXME What is roles?
+      ##roles: null
+      keywords:
+        type: array
+        items:
+          type: string
+      id:
+        type: string
+        example: "fb55ec78-f907-4422-aa37-0d6b501b03b6"
+      title:
+        type: string
+        example: "Preface: Fast Fourier Transforms"
+      mediaType:
+        $ref: "#/definitions/MediaType"
+      content:
+        type: string
+      tree:
+        type: object
+      subjects:
+        type: array
+        items:
+          type: string
+          enum:
+            - "Arts"
+            - "Business"
+            - "Humanities"
+            - "Mathematics and Statistics"
+            - "Science and Technology"
+            - "Social Sciences"
+      legacy_id:
+        type: string
+      legacy_version:
+        type: string
+      resources:
+        type: array
+        items:
+          type: object
+          properties:
+            media_type:
+              type: string
+            id:
+              type: string
+            filename:
+              type: string
+      publishers:
+        $ref: "#/definitions/PersonList"
+      authors:
+        $ref: "#/definitions/PersonList"
+      licensors:
+        $ref: "#/definitions/PersonList"
+      submitter:
+        $ref: "#/definitions/Person"
+      parent:
+        type: object
+        # TODO This is kind of a strange object
+        # description: ???
+      parentTitle:
+        type: string
+        # description: ???
+        x-nullable: true
+      parentVersion:
+        type: string
+        # description: ???
+        x-nullable: true
+      parentId:
+        type: string
+        # description: ???
+        x-nullable: true
+      parentAuthors:
+        $ref: "#/definitions/PersonList"
+      stateid:
+        type: integer
+      shortId:
+        type: string
+      language:
+        type: string
+      license:
+        type: object
+        properties:
+          url:
+            type: string
+          code:
+            type: string
+          name:
+            type: string
+          version:
+            type: string
+      created:
+        type: string
+        example: "2008-05-22T20:33:13Z"
+      docType:
+        type: string
+        # description: ???
+        x-nullable: true
+      buyLink:
+        type: string
+        x-nullable: true
+      history:
+        type: array
+        items:
+          type: object
+          properties:
+            changes:
+              type: string
+              description: submit log for this revision
+            version:
+              type: string
+              description: version of this revision
+            revised:
+              type: string
+              description: datetime of the revision
+            publisher:
+              $ref: "#/definitions/Person"

--- a/press/views/api-docs/swagger.yaml
+++ b/press/views/api-docs/swagger.yaml
@@ -668,6 +668,40 @@ paths:
           description: Not found
       tags:
         - content
+  '/api/v3/publish':
+    post:
+      summary: Add a peice of content to the repository
+      description: ''
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Publication'
+        '400':
+          description: error during publication
+          schema:
+            $ref: '#/definitions/PublicationError'
+      consumes:
+        - application/x-www-form-urlencoded
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - in: formData
+          name: publisher
+          type: string
+          description: The user id of the publisher
+          required: true
+        - in: formData
+          name: message
+          type: string
+          description: The publication message for this revision
+          required: true
+        - in: formData
+          name: file
+          type: file
+          description: The litezip file containing the content
+          required: true
 definitions:
   MediaType:
     type: string
@@ -828,3 +862,39 @@ definitions:
               description: datetime of the revision
             publisher:
               $ref: "#/definitions/Person"
+  Publication:
+    type: array
+    items:
+      type: object
+      required:
+        - source_id
+        - id
+        - version
+        - url
+    properties:
+      source_id:
+        type: string
+        description: id of the content item from the submitted litezip
+      id:
+        type: string
+      version:
+        type: string
+      url:
+        type: string
+  PublicationError:
+    type: object
+    required:
+      - messages
+    properties:
+      messages:
+        type: array
+        items:
+          type: object
+          required:
+            - id
+            - message
+          properties:
+            id:
+              type: integer
+            message:
+              type: string

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -7,3 +7,5 @@ cnx-db==1.4.0
 cnx-litezip==1.3.0
 
 pyramid==1.9.1
+
+pyramid_swagger==2.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pathlib
 import random
 import shutil
 import tempfile
+import zipfile
 
 import jinja2
 import pytest
@@ -348,6 +349,23 @@ class _ContentUtil:
         modules = list(self._flatten_collection_tree_to_modules(tree))
         self._update_collection(collection, tree)
         return collection, tree, modules
+
+    def mk_zipfile_from_litezip_struct(self, struct):
+        zip_file = self._mkdir() / 'contents.zip'
+        with zipfile.ZipFile(str(zip_file), 'w') as zb:
+            for model in struct:
+                if isinstance(model, Collection):
+                    file = model.file
+                    rel_file_path = model.file.name
+                else:  # Module
+                    file = model.file
+                    # FIXME Workaround for the lack of actual m##### named
+                    #       directories. This is because the 'new' content
+                    #       story has not been implemented yet.
+                    rel_file_path = pathlib.Path(model.id) / model.file.name
+                zb.write(str(file), str(rel_file_path))
+                # TODO Write resources into this zipfile
+        return zip_file
 
 
 @pytest.fixture(scope='session')

--- a/tests/functional/views/test_publishing.py
+++ b/tests/functional/views/test_publishing.py
@@ -1,0 +1,83 @@
+
+
+def test_publishing_invalid_zip(tmpdir, webapp):
+    file = tmpdir.mkdir('test').join('foo.txt')
+    file.write('foo bar')
+
+    publisher = 'user1'
+    message = 'test http publish'
+
+    # Submit a publication
+    with file.open('rb') as fb:
+        file_data = [('file', 'contents.zip', fb.read(),)]
+    form_data = {'publisher': publisher, 'message': message}
+    resp = webapp.post('/api/v3/publish', form_data, upload_files=file_data,
+                       expect_errors=True)
+    assert resp.status_code == 400
+    expected_msgs = [
+        {'id': 1,
+         'message': 'The given file is not a valid zip formatted file.'},
+    ]
+    assert resp.json['messages'] == expected_msgs
+
+
+def test_publishing_revision_litezip(
+        content_util, persist_util, webapp, db_engines, db_tables):
+    # Insert initial collection and modules.
+    collection, tree, modules = content_util.gen_collection()
+    modules = list([persist_util.insert_module(m) for m in modules])
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    collection = persist_util.insert_collection(collection)
+
+    # Insert a new module ...
+    new_module = content_util.gen_module(relative_to=collection)
+    new_module = persist_util.insert_module(new_module)
+    # ... remove second element from the tree ...
+    tree.pop(1)
+    # ... and append the new module to the tree.
+    tree.append(content_util.make_tree_node_from(new_module))
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    struct = tuple([collection, new_module])
+
+    file = content_util.mk_zipfile_from_litezip_struct(struct)
+
+    publisher = 'user1'
+    message = 'test http publish'
+
+    # Submit a publication
+    with file.open('rb') as fb:
+        file_data = [('file', 'contents.zip', fb.read(),)]
+    form_data = {'publisher': publisher, 'message': message}
+    resp = webapp.post('/api/v3/publish', form_data, upload_files=file_data)
+    assert resp.status_code == 200
+
+    # Check resulting data. (id mapping and urls)
+    id_mapping = {x['source_id']: x for x in resp.json}
+    for model in struct:
+        assert model.id in id_mapping
+        publication_record = id_mapping[model.id]
+        assert publication_record['id'] == model.id
+        assert publication_record['version'] == '1.2'
+        url = publication_record['url']
+        # FIXME We should visit this URL rather than check it's parts.
+        assert '/content/{}/{}'.format(model.id, '1.2') in url
+
+    # FIXME This functional test should not be directly communicating
+    #       with the database. Instead it should be using other http
+    #       routes to verify the contents.
+    # Check the content is actually in the database
+    #   and that the correct publisher and message was attributed.
+    # Checking for content details is out-of-scope for this test.
+    t = db_tables
+    for model in struct:
+        stmt = (
+            t.modules.select()
+            .where(t.modules.c.moduleid == model.id)
+            .order_by(t.modules.c.major_version.desc())
+            .limit(1))
+        result = db_engines['common'].execute(stmt).fetchone()
+        assert result.version == '1.2'
+        assert result.submitter == publisher
+        assert result.submitlog == message


### PR DESCRIPTION
This adds a view to receive a POST containing a litezip structured zipfile for publication.

At this time it is fairly simple. There is no validation other than validating the uploaded file is indeed a zipfile. Later changes will add various content validations to this view.