### PR TITLE
Modify the testing script and config to report code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,10 @@ before_install:
   - sudo apt-get install python3.4-venv
   # Create the virtual env and lint the codebase
   - make lint VENV_EXTRA_ARGS="--system-site-packages"
-  # # Install the coverage utility and codecov reporting utility
-  # - python -m pip install codecov
 script:
-  # This is the same as `python setup.py test` with a coverage wrapper.
-  - make test
-# XXX We'll bring this back later...
-# after_success:
-#   # Report test coverage to codecov.io
-#   - codecov
+  # Report test coverage to codecov.io
+  # See also: https://docs.codecov.io/docs/testing-with-docker
+  - ci_env=`bash <(curl -s https://codecov.io/env)`
+  - docker-compose run $ci_env web bin/test
 notifications:
   email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
 # Needed for testing
 RUN set -x \
     && apt-get update \
-    && apt-get install wamerican --no-install-recommends -y
+    && apt-get install wamerican curl --no-install-recommends -y
 
 COPY requirements /tmp/requirements
 

--- a/bin/test
+++ b/bin/test
@@ -7,3 +7,11 @@ set -x
 #   - The pytest coverage and verbosity options are configured in setup.cfg
 python -m pytest --strict $@
 python -m coverage html
+
+# Report test coverage to codecov.io
+# See also: https://docs.codecov.io/docs/testing-with-docker
+if [ "$TRAVIS" = "true" ];
+then
+    # Report coverage to codecov
+    bash <(curl -s https://codecov.io/bash)
+fi


### PR DESCRIPTION
This enables code coverage on this project, which was disabled shortly after it became containerized. This uses one of, if not the recommended easiest, documented ways to connect codecov to test runs using travis-ci and a contained software entity.