### PR TITLE
Make parsing the abstract optional

### DIFF
--- a/press/parsers/common.py
+++ b/press/parsers/common.py
@@ -49,7 +49,7 @@ def parse_common_properties(elm_tree):
         'licensors': role_xpath('//md:role[@type="licensor"]/text()'),
         'keywords': tuple(xpath('//md:keywordlist/md:keyword/text()')),
         'subjects': tuple(xpath('//md:subjectlist/md:subject/text()')),
-        'abstract': xpath('//md:abstract/text()')[0],
+        'abstract': _maybe(xpath('//md:abstract/text()')),
     }
 
     # Note, Press does not parse or update user (aka "actor" in the xml)

--- a/tests/unit/parsers/test_common.py
+++ b/tests/unit/parsers/test_common.py
@@ -1,0 +1,20 @@
+from litezip.main import COLLECTION_NSMAP
+from lxml import etree
+
+from press.parsers.common import parse_common_properties
+
+
+# https://github.com/Connexions/cnx-press/issues/17
+def test_parse_common_properties_without_abstract(litezip_valid_litezip):
+    # Copy over and modify the collection.xml file.
+    with (litezip_valid_litezip / 'collection.xml').open() as origin:
+        xml = etree.parse(origin)
+        elm = xml.xpath('//md:abstract',
+                        namespaces=COLLECTION_NSMAP)[0]
+        elm.getparent().remove(elm)
+
+        # Test the parser doesn't error when the abstract is missing.
+        # given a ElementTree object,
+        props = parse_common_properties(xml)
+        # parse the metadata into a dict and check for the abstract.
+        assert props['abstract'] is None


### PR DESCRIPTION
This is in accordance with the MDML RNG spec, which says the abstract
is an optional element.

Fixes #17