### PR TITLE
Include an encapsulating directory when parsing litezip payloads

### DIFF
--- a/press/publishing.py
+++ b/press/publishing.py
@@ -25,7 +25,13 @@ def persist_file_to_filesystem(file):
     return filepath
 
 
-def expand_zip(filepath):
+def expand_zip(file):
+    """Expand a zip file into a temporary directory and return the path
+    to the expanded directory location (a ``pathlib.Path``).
+    ``file`` can be a path to a file (a string), a file-like object
+    or a path-like object.
+
+    """
     settings = get_current_registry().settings
     shared_directory = Path(settings['shared_directory'])
     _names = tempfile._get_candidate_names()
@@ -38,6 +44,6 @@ def expand_zip(filepath):
         break
     expand_path = dir
 
-    with filepath.open('rb') as fb, zipfile.ZipFile(fb) as z:
+    with zipfile.ZipFile(file) as z:
         z.extractall(path=str(expand_path))
     return expand_path

--- a/press/publishing.py
+++ b/press/publishing.py
@@ -6,6 +6,7 @@ from pyramid.threadlocal import get_current_registry
 
 
 __all__ = (
+    'discover_content_dir',
     'expand_zip',
     'persist_file_to_filesystem',
 )
@@ -47,3 +48,14 @@ def expand_zip(file):
     with zipfile.ZipFile(file) as z:
         z.extractall(path=str(expand_path))
     return expand_path
+
+
+def discover_content_dir(dir):
+    """Given an expanded litezip directory path (a ``pathlib.Path``),
+    discover the name of the contents directory within it.
+
+    """
+    for path in dir.iterdir():
+        if path.is_dir():
+            return path
+    return None

--- a/press/views/publishing.py
+++ b/press/views/publishing.py
@@ -6,6 +6,7 @@ from pyramid.view import view_config
 
 from ..legacy_publishing import publish_litezip
 from ..publishing import (
+    discover_content_dir,
     expand_zip,
     persist_file_to_filesystem,
 )
@@ -37,6 +38,7 @@ def publish(request):
     upload_filepath = persist_file_to_filesystem(uploaded_file)
     logging.debug('write upload to: {}'.format(upload_filepath))
     litezip_dir = expand_zip(upload_filepath)
+    litezip_dir = discover_content_dir(litezip_dir)
 
     litezip_struct = parse_litezip(litezip_dir)
     id_mapping = publish_litezip(litezip_struct, (publisher, message),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,17 +352,18 @@ class _ContentUtil:
 
     def mk_zipfile_from_litezip_struct(self, struct):
         zip_file = self._mkdir() / 'contents.zip'
+        base_dir = pathlib.Path(struct[0].id)
         with zipfile.ZipFile(str(zip_file), 'w') as zb:
             for model in struct:
                 if isinstance(model, Collection):
                     file = model.file
-                    rel_file_path = model.file.name
+                    rel_file_path = base_dir / model.file.name
                 else:  # Module
                     file = model.file
                     # FIXME Workaround for the lack of actual m##### named
                     #       directories. This is because the 'new' content
                     #       story has not been implemented yet.
-                    rel_file_path = pathlib.Path(model.id) / model.file.name
+                    rel_file_path = base_dir / model.id / model.file.name
                 zb.write(str(file), str(rel_file_path))
                 # TODO Write resources into this zipfile
         return zip_file

--- a/tests/unit/test_publishing.py
+++ b/tests/unit/test_publishing.py
@@ -5,6 +5,7 @@ from zipfile import ZipFile
 from pyramid import testing as pyramid_testing
 
 from press.publishing import (
+    discover_content_dir,
     expand_zip,
     persist_file_to_filesystem,
 )
@@ -52,3 +53,33 @@ def test_expand_zip(app, tmpdir):
     expanded_files = list([str(x)
                            for x in deflate_path(expand_path, expand_path)])
     assert sorted(expanded_files) == sorted(files)
+
+
+def test_discover_content_dir(tmpdir):
+    root = Path(str(tmpdir.mkdir('root')))
+    dir = root / 'foo'
+    dir.mkdir()
+
+    found_dir = discover_content_dir(root)
+    assert found_dir == dir
+
+
+def test_discover_content_dir_with_multiple_dirs(tmpdir):
+    root = Path(str(tmpdir.mkdir('root')))
+    (root / 'foo').mkdir()
+    (root / 'bar').mkdir()
+    dir = root / 'alp'
+    dir.mkdir()
+
+    found_dir = discover_content_dir(root)
+    assert found_dir == dir
+
+
+def test_discover_content_dir_with_no_dirs(tmpdir):
+    root = Path(str(tmpdir.mkdir('root')))
+    for filename in ('foo', 'bar', 'baz'):
+        with (root / filename).open('w') as fb:
+            fb.write('smoo')
+
+    found_dir = discover_content_dir(root)
+    assert found_dir is None

--- a/tests/unit/test_publishing.py
+++ b/tests/unit/test_publishing.py
@@ -1,7 +1,13 @@
 import io
 from pathlib import Path
+from zipfile import ZipFile
 
 from pyramid import testing as pyramid_testing
+
+from press.publishing import (
+    expand_zip,
+    persist_file_to_filesystem,
+)
 
 
 def test_persist_file_to_filesystem(tmpdir):
@@ -12,10 +18,37 @@ def test_persist_file_to_filesystem(tmpdir):
         'shared_directory': str(shared_directory),
     }
     with pyramid_testing.testConfig(settings=settings):
-        from press.publishing import persist_file_to_filesystem
         filepath = persist_file_to_filesystem(file_content)
 
     with filepath.open('rb') as fb:
         assert fb.read() == file_content.read()
 
     assert filepath in [fp for fp in shared_directory.iterdir()]
+
+
+def test_expand_zip(app, tmpdir):
+    zipfile = io.BytesIO()
+    files = [
+        'foo/bar.txt', 'foo/mar.txt',
+        'bar/foo.txt', 'bar/moo.txt',
+        'smoo.txt',
+    ]
+    with ZipFile(zipfile, mode='a') as zb:
+        for file in files:
+            zb.writestr(file, 'foobar')
+    # Reset file pointer location
+    zipfile.seek(0)
+
+    with app:
+        expand_path = expand_zip(zipfile)
+
+    def deflate_path(path, root, parent=None):
+        if path.is_dir():
+            for x in path.iterdir():
+                yield from deflate_path(x, root, path)
+        else:
+            yield path.relative_to(root)
+
+    expanded_files = list([str(x)
+                           for x in deflate_path(expand_path, expand_path)])
+    assert sorted(expanded_files) == sorted(files)


### PR DESCRIPTION
This adds an encapsulating directory to the expected litezip file structure. This really isn't necessary, but it's how the completezip zip was fashioned. We'll stick with it because it could provide an option for publishing more than one collection in a litezip payload, though I'm hoping it never comes to that.

This change set also contains an adjustment to the expand_zip function, which in Python 3 can take a path (a string), a file object, or path-like object (pathlib.Path).

Fixes #19 