### PR TITLE
Add a dedicated testing configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ $(STATEDIR)/env/pyvenv.cfg : $(_REQUIREMENTS_FILES)
 $(STATEDIR)/docker-build: Dockerfile requirements/main.txt requirements/deploy.txt
 	# Build our docker container(s) for this project.
 	docker-compose build
+	docker-compose -f docker-compose.testing.yml build
 
 	# Mark the state so we don't rebuild this needlessly.
 	mkdir -p $(STATEDIR)
@@ -97,7 +98,7 @@ help-test :
 	@echo "    (see also setup.cfg's pytest configuration)"
 
 test :
-	docker-compose run --rm web bin/test $(TEST_EXTRA_ARGS) $(TEST)
+	docker-compose -f docker-compose.testing.yml run --rm test bin/test $(TEST_EXTRA_ARGS) $(TEST)
 
 # /Test
 
@@ -163,6 +164,7 @@ build:
 
 	# Build our docker container(s) for this project.
 	docker-compose build
+	docker-compose -f docker-compose.testing.yml build
 
 	# Mark the state so we don't rebuild this needlessly.
 	mkdir -p $(STATEDIR)

--- a/bin/test
+++ b/bin/test
@@ -2,6 +2,13 @@
 set -e
 set -x
 
+# Wait for the database to start up. The first time takes a little longer.
+until python -c "import os, psycopg2 as p; p.connect(os.environ['DB_URL'])"; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+>&2 echo "Postgres is up - continuing execution"
+
 # Run the unittests
 #   - Let nothing go unnoticed by using `--strict`
 #   - The pytest coverage and verbosity options are configured in setup.cfg

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -1,0 +1,24 @@
+version: '2'
+# See also, https://docs.docker.com/compose/extends/#multiple-compose-files
+services:
+  # Our test services:
+  test_db:
+    extends:
+      file: docker-compose.yml
+      service: base_db
+    ports:
+      - "65432:5432"
+    environment:
+      - DB_URL=postgresql://rhaptos@/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@/repository
+  test:
+    extends:
+      file: docker-compose.yml
+      service: app
+    command: bin/test
+    links:
+      - test_db
+    environment:
+      - SHARED_DIR=/app/var
+      - DB_URL=postgresql://rhaptos@test_db/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@test_db/repository

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,18 @@ services:
       - ./var:/app/var:z
     environment:
       - SHARED_DIR=/app/var
-  db:
+      - DB_URL=postgresql://rhaptos@db/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@db/repository
+  base_db:
     image: openstax/cnx-db:1.5.1
-    ports:
-      - "5432:5432"
     environment:
       - DB_URL=postgresql://rhaptos@/repository
       - DB_SUPER_URL=postgresql://rhaptos_admin@/repository
+  db:
+    extends:
+      service: base_db
+    ports:
+      - "5432:5432"
   web:
     extends:
       service: app
@@ -30,5 +35,3 @@ services:
       - db
     environment:
       - SHARED_DIR=/app/var
-      - DB_URL=postgresql://rhaptos@db/repository
-      - DB_SUPER_URL=postgresql://rhaptos_admin@db/repository


### PR DESCRIPTION
This provides us with a configuration that is dedicated to testing. It's helpful in the development workflow because it means there are two different composed environments that won't collide. Prior to this I was running into paving over my database that was loaded with the slim dump. This means I can have a database containing content and another instance that is used solely for testing.