### PR TITLE
Ignore SQLAlchemy SAWarning about unsupported reflection elements

### DIFF
--- a/press/config.py
+++ b/press/config.py
@@ -1,6 +1,8 @@
 import os.path
+import warnings
 
 from pyramid.config import Configurator
+from sqlalchemy.exc import SAWarning
 
 
 def discover_set(settings, setting_name, env_var, default=None):
@@ -39,7 +41,10 @@ def configure(settings=None):
     config = Configurator(settings=settings)
     config.include('.views')
 
-    config.include('cnxdb.contrib.pyramid')
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=SAWarning)
+        config.include('cnxdb.contrib.pyramid')
+
     config.scan()
     return config
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import random
 import shutil
 import tempfile
 import zipfile
+import warnings
 
 import jinja2
 import pytest
@@ -83,7 +84,11 @@ SUBJECTS = (
 @pytest.fixture(scope='session')
 def db_tables_session_scope(db_engines):
     from cnxdb.contrib.pytest import db_tables
-    return db_tables(db_engines)
+    with warnings.catch_warnings():
+        # Ignore SQLAlchemy SAWarning about unsupported reflection elements.
+        warnings.simplefilter('ignore')
+        tables = db_tables(db_engines)
+    return tables
 
 
 @pytest.fixture


### PR DESCRIPTION
This specifically ignores the warnings coming out of the database table
reflection process. It removes these warnings from the runtime and test output,
which of course makes the output easier to read.

These catch wrappings should probably be moved to cnx-db. I may do that as well...