### PR TITLE
Provide structured application request logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   web:
     extends:
       service: app
-    command: gunicorn -b 0.0.0.0:6543 -n press --reload wsgi:app
+    command: gunicorn -b 0.0.0.0:6543 --access-logfile - --error-logfile - -n press --reload wsgi:app
     ports:
       - "80:6543"
     links:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,6 +11,19 @@ Configuration
 .. automodule:: press.config
    :members:
 
+.. seealso::
+
+   See also :ref:`configuration_chapter` for environment variables,
+   defaults and required settings.
+
+.. automodule:: press.logging
+   :members: includeme
+
+.. seealso::
+
+   See also :ref:`configuration_chapter__logging` for information
+   on how to configure logging.
+
 Publishing
 ==========
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -4,6 +4,11 @@
 Configuration
 =============
 
+.. _configuration_chapter__settings:
+
+Settings
+--------
+
 The application is configured via environment variables.
 The following application settings are mapped to environment variables.
 
@@ -14,9 +19,22 @@ Setting                          Env Variable            Required?
 ``db.readonly.url``              ``DB_READONLY_URL``     no
 ``db.super.url``                 ``DB_SUPER_URL``        no
 ``shared_directory``             ``SHARED_DIR``          yes
+``debug``                        ``DEBUG``               no
+``logging.level``                ``DEBUG``               no
 ===============================  ======================  =============
-
 
 See `cnx-db configuration docs
 <https://cnx-db.readthedocs.io/en/latest/config.html>`_
 for more information about configuring the database features.
+
+For information on how the configuration is coded see,
+:func:`press.config.configure`.
+
+.. _configuration_chapter__logging:
+
+Logging
+-------
+
+The logging configuration is by default set to ``INFO`` level logging.
+If you wish to receive ``DEBUG`` level logging you should set the
+``DEBUG`` environment variable to ``true``.

--- a/press/config.py
+++ b/press/config.py
@@ -2,10 +2,12 @@ import os.path
 import warnings
 
 from pyramid.config import Configurator
+from pyramid.config.settings import asbool
 from sqlalchemy.exc import SAWarning
 
 
-def discover_set(settings, setting_name, env_var, default=None):
+def discover_set(settings, setting_name, env_var, default=None,
+                 modifier=None):
     """Discover a setting from environment variables and add it
     to the settings dictionary. A ``default`` value can be supplied
     and used when the environment variable can not be found.
@@ -18,11 +20,16 @@ def discover_set(settings, setting_name, env_var, default=None):
     :type env_var: str
     :param default: default value to give the setting when the environment
                     variable is not set and the setting is already empty
+    :param modifier: a callable used to modify the value (e.g. type cast)
+    :type modifier: callable
     :returns: None
 
     """
     if env_var in os.environ:
-        settings[setting_name] = os.environ[env_var]
+        value = os.environ[env_var]
+        if callable(modifier):
+            value = modifier(value)
+        settings[setting_name] = value
     elif default is not None:
         settings.setdefault(setting_name, default)
 
@@ -36,6 +43,9 @@ def configure(settings=None):
     discover_set(settings, 'shared_directory', 'SHARED_DIR')
     assert os.path.exists(settings['shared_directory'])  # required
     # TODO check permissions for write access
+
+    discover_set(settings, 'debug', 'DEBUG', False, asbool)
+    settings['logging.level'] = settings['debug'] and 'DEBUG' or 'INFO'
 
     # Create the configuration object
     config = Configurator(settings=settings)

--- a/press/config.py
+++ b/press/config.py
@@ -39,6 +39,7 @@ def configure(settings=None):
 
     # Create the configuration object
     config = Configurator(settings=settings)
+    config.include('.logging')
     config.include('.views')
 
     with warnings.catch_warnings():

--- a/press/logging.py
+++ b/press/logging.py
@@ -1,9 +1,23 @@
 import logging.config
+import uuid
 
 import structlog
 
 
+def _create_id(request):
+    """Request attribute factory for creating a unique id."""
+    return str(uuid.uuid4())
+
+
+def _create_logger(request):
+    """Request attribute factory to give access to the logger."""
+    logger = structlog.get_logger("press.request")
+    logger = logger.bind(request_id=request.id)
+    return logger
+
+
 def includeme(config):
+    """Configure logging for the application"""
     logging.config.dictConfig({
         'version': 1,
         'disable_existing_loggers': False,
@@ -39,3 +53,9 @@ def includeme(config):
     logger = structlog.get_logger('press.logging')
     logger.info('logging configuration initialized')
     logger.debug('debug logging enabled')
+
+    # Give every request a unique identifier.
+    config.add_request_method(_create_id, name="id", reify=True)
+
+    # Add a log method to every request.
+    config.add_request_method(_create_logger, name="log", reify=True)

--- a/press/logging.py
+++ b/press/logging.py
@@ -1,0 +1,41 @@
+import logging.config
+
+import structlog
+
+
+def includeme(config):
+    logging.config.dictConfig({
+        'version': 1,
+        'disable_existing_loggers': False,
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'level': 'NOTSET',
+                'stream': 'ext://sys.stdout',
+            },
+        },
+        'root': {
+            'level': config.registry.settings.get('logging.level', 'INFO'),
+            'handlers': ['console'],
+        },
+    })
+
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S",
+                                             utc=False),
+            structlog.processors.KeyValueRenderer(),
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+    )
+
+    logger = structlog.get_logger('press.logging')
+    logger.info('logging configuration initialized')
+    logger.debug('debug logging enabled')

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -9,3 +9,5 @@ cnx-litezip==1.3.0
 pyramid==1.9.1
 
 pyramid_swagger==2.6.0
+
+structlog

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,8 +2,15 @@
 -r ./main.txt
 
 jinja2==2.10
+
+pretend
+
 pytest==3.4.0
+
 pytest-cov==2.5.1
+
 python-dateutil==2.6.1
+
 recordclass==0.5
+
 WebTest >= 1.3.1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -69,3 +69,18 @@ def test_discover_set_with_env_var_and_existing():
     assert s[s_name] == val
 
     del os.environ[var]
+
+
+def test_discover_set_with_env_var_and_modifier():
+    s = {}
+    s_name = 'baz'
+    var = 'FOO'
+    val = 'bar'
+    os.environ[var] = val
+
+    discover_set(s, s_name, var, modifier=str.upper)
+
+    assert s_name in s
+    assert s[s_name] == val.upper()
+
+    del os.environ[var]

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,92 @@
+import pytest
+import structlog
+from pyramid import testing as pyramid_testing
+
+from press.logging import includeme
+
+
+class FauxTimeStamper(object):
+
+    def __new__(cls, fmt=None, utc=True, key="timestamp"):
+
+        def stamper(self, _, __, event_dict):
+            event_dict[key] = 'round and round'
+            return event_dict
+
+        return type("TimeStamper", (object,), {"__call__": stamper})()
+
+
+@pytest.fixture
+def mock_timestamper(request):
+    """Create a fake timestamper for easier assertions"""
+    from press.logging import structlog as x_structlog
+    original = x_structlog.processors.TimeStamper
+
+    def reset_TimeStamper():
+        setattr(x_structlog.processors, 'TimeStamper', original)
+
+    request.addfinalizer(reset_TimeStamper)
+    x_structlog.processors.TimeStamper = FauxTimeStamper
+
+
+def test_init(capsys, mock_timestamper):
+    logger = structlog.get_logger()
+
+    # Configure pyramid app
+    with pyramid_testing.testConfig() as config:
+        config.include(includeme)
+        # Create some log messages
+        logger.info('info msg')
+        logger.debug('debug msg')
+        logger.error('error msg')
+
+    # Check for results
+    captured = capsys.readouterr()
+    expected = (
+        "event='logging configuration initialized' logger='press.logging'"
+        " level='info' timestamp='round and round'"
+        "\n"
+        "event='info msg' logger='tests.unit.test_logging'"
+        " level='info' timestamp='round and round'"
+        "\n"
+        "event='error msg' logger='tests.unit.test_logging'"
+        " level='error' timestamp='round and round'"
+        "\n"
+    )
+    assert captured.out == expected
+    assert captured.err == ''
+
+
+def test_init_with_debug(capsys, mock_timestamper):
+    logger = structlog.get_logger()
+
+    # Configure pyramid app
+    settings = {'logging.level': 'DEBUG'}
+    with pyramid_testing.testConfig(settings=settings) as config:
+        config.include(includeme)
+        # Create some log messages
+        logger.info('info msg')
+        logger.debug('debug msg')
+        logger.error('error msg')
+
+    # Check for results
+    captured = capsys.readouterr()
+    expected = (
+        "event='logging configuration initialized' logger='press.logging'"
+        " level='info' timestamp='round and round'"
+        "\n"
+        "event='debug logging enabled' logger='press.logging'"
+        " level='debug' timestamp='round and round'"
+        "\n"
+        "event='info msg' logger='tests.unit.test_logging'"
+        " level='info' timestamp='round and round'"
+        "\n"
+        "event='debug msg' logger='tests.unit.test_logging'"
+        " level='debug' timestamp='round and round'"
+        "\n"
+        "event='error msg' logger='tests.unit.test_logging'"
+        " level='error' timestamp='round and round'"
+        "\n"
+    )
+    assert captured.out == expected
+    assert captured.err == ''


### PR DESCRIPTION
This adds the framework for logging. None of the existing logic uses it yet, except for application startup code.

This also adds a "debug" concept, which we'll use to turn on debug logging. Later it will be used to enable debugging tools.