### PR TITLE
Provide content validation during publication of a litezip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   # Report test coverage to codecov.io
   # See also: https://docs.codecov.io/docs/testing-with-docker
   - ci_env=`bash <(curl -s https://codecov.io/env)`
+  - docker-compose build
   - docker-compose run $ci_env web bin/test
 notifications:
   email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,59 @@ RUN set -x \
     && apt-get update \
     && apt-get install wamerican curl --no-install-recommends -y
 
+
+# ###
+# Java install,
+#   copied from https://github.com/docker-library/openjdk/blob/93316d3b14379d29fe0cd363bd6839eb8dd8cc7b/7-jre/Dockerfile
+# ###
+
+# A few problems with compiling Java from source:
+#  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
+#       really hairy.
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bzip2 \
+		unzip \
+		xz-utils \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/sh'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-7-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home/jre
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y openjdk-7-jre-headless; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# verify that "docker-java-home" returns what we expect
+	[ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
+	\
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+	update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+	update-alternatives --query java | grep -q 'Status: manual'
+
+# ###
+# / End copy for Java Install
+# ###
+
+
 COPY requirements /tmp/requirements
 
 # Install Python Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6-jessie
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /app/

--- a/tests/_templates/collection.xml
+++ b/tests/_templates/collection.xml
@@ -23,6 +23,12 @@
     <md:revised>{{ metadata.revised }}</md:revised>
     <md:actors>
       {# Currently these values are ignored #}
+      {# Must have one actor for this element to be valid, so here is a fake #}
+      <md:person>
+        <md:firstname>College</md:firstname>
+        <md:surname>Physics</md:surname>
+        <md:fullname>OpenStax College Physics</md:fullname>
+      </md:person>
     </md:actors>
     <md:roles>
       <md:role type="author">{% for r in metadata.authors -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
@@ -30,11 +36,13 @@
       <md:role type="licensor">{% for r in metadata.licensors -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
     </md:roles>
     <md:license url="{{ metadata.license_url }}" />
+    {%- if metadata.keywords %}
     <md:keywordlist>
       {%- for keyword in metadata.keywords %}
       <md:keyword>{{ keyword }}</md:keyword>
       {%- endfor %}
     </md:keywordlist>
+    {%- endif %}
     <md:subjectlist>
       {%- for subject in metadata.subjects %}
       <md:subject>{{ subject }}</md:subject>

--- a/tests/_templates/module.xml
+++ b/tests/_templates/module.xml
@@ -13,6 +13,12 @@
   <md:revised>{{ metadata.revised }}</md:revised>
   <md:actors>
     {# Currently these values are ignored #}
+    {# Must have one actor for this element to be valid, so here is a fake #}
+    <md:person>
+      <md:firstname>College</md:firstname>
+      <md:surname>Physics</md:surname>
+      <md:fullname>OpenStax College Physics</md:fullname>
+    </md:person>
   </md:actors>
   <md:roles>
     <md:role type="author">{% for r in metadata.authors -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
@@ -20,11 +26,13 @@
     <md:role type="licensor">{% for r in metadata.licensors -%}{{ r }}{{ ' ' }}{%- endfor %}</md:role>
   </md:roles>
   <md:license url="{{ metadata.license_url }}" />
+  {%- if metadata.keywords %}
   <md:keywordlist>
     {%- for keyword in metadata.keywords %}
     <md:keyword>{{ keyword }}</md:keyword>
     {%- endfor %}
   </md:keywordlist>
+  {%- endif %}
   <md:subjectlist>
     {%- for subject in metadata.subjects %}
     <md:subject>{{ subject }}</md:subject>

--- a/tests/functional/views/test_publishing.py
+++ b/tests/functional/views/test_publishing.py
@@ -1,3 +1,6 @@
+from lxml import etree
+
+from litezip.main import COLLECTION_NSMAP
 
 
 def test_publishing_invalid_zip(tmpdir, webapp):
@@ -17,6 +20,98 @@ def test_publishing_invalid_zip(tmpdir, webapp):
     expected_msgs = [
         {'id': 1,
          'message': 'The given file is not a valid zip formatted file.'},
+    ]
+    assert resp.json['messages'] == expected_msgs
+
+
+def test_publishing_invalid_revision_litezip(
+        content_util, persist_util, webapp, db_engines, db_tables):
+    # Insert initial collection and modules.
+    collection, tree, modules = content_util.gen_collection()
+    modules = list([persist_util.insert_module(m) for m in modules])
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    collection = persist_util.insert_collection(collection)
+
+    # Insert a new module ...
+    new_module = content_util.gen_module(relative_to=collection)
+    new_module = persist_util.insert_module(new_module)
+    # ... remove second element from the tree ...
+    tree.pop(1)
+    # ... and append the new module to the tree.
+    tree.append(content_util.make_tree_node_from(new_module))
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    struct = tuple([collection, new_module])
+
+    # Modify the collection content to make it invalid.
+    with collection.file.open('rb') as fb:
+        xml = etree.parse(fb)
+        elm = xml.xpath('//col:metadata', namespaces=COLLECTION_NSMAP)[0]
+        # Add an invalid element.
+        elm.insert(
+            0,
+            etree.Element(
+                '{{{}}}wordlist'.format(COLLECTION_NSMAP['md']),
+                nsmap=COLLECTION_NSMAP))
+    with collection.file.open('wb') as fb:
+        # Write the modified xml back to file.
+        fb.write(etree.tostring(xml))
+    # Modify the module content to make it invalid.
+    with new_module.file.open('rb') as fb:
+        xml = etree.parse(fb)
+        query = xml.xpath('//md:keywordlist', namespaces=COLLECTION_NSMAP)
+        if query:
+            elm = query[0]
+            elm.getparent().remove(elm)
+        elm = xml.xpath('//c:metadata', namespaces=COLLECTION_NSMAP)[0]
+        # Add a valid element, but with empty (invalid) contents.
+        elm.insert(
+            0,
+            etree.Element(
+                '{{{}}}keywordlist'.format(COLLECTION_NSMAP['md']),
+                nsmap=COLLECTION_NSMAP))
+        # Add an invalid element.
+        elm.insert(
+            0,
+            etree.Element(
+                '{{{}}}wordlist'.format(COLLECTION_NSMAP['md']),
+                nsmap=COLLECTION_NSMAP))
+    with new_module.file.open('wb') as fb:
+        # Write the modified xml back to file.
+        fb.write(etree.tostring(xml))
+
+    # Compress to zip file as payload
+    file = content_util.mk_zipfile_from_litezip_struct(struct)
+
+    publisher = 'user1'
+    message = 'test http publish'
+
+    # Submit a publication
+    with file.open('rb') as fb:
+        file_data = [('file', 'contents.zip', fb.read(),)]
+    form_data = {'publisher': publisher, 'message': message}
+    resp = webapp.post('/api/v3/publish', form_data, upload_files=file_data,
+                       expect_errors=True)
+    assert resp.status_code == 400
+    expected_msgs = [
+        {'id': 2,
+         'message': 'validation issue',
+         'item': 'collection.xml',
+         'error': ('3:319 -- error: unknown element "wordlist" from '
+                   'namespace "http://cnx.rice.edu/mdml"'),
+         },
+        {'id': 2,
+         'message': 'validation issue',
+         'item': '{}/index.cnxml'.format(new_module.id),
+         'error': ('5:460 -- error: unknown element "wordlist" '
+                   'from namespace "http://cnx.rice.edu/mdml"'),
+         },
+        {'id': 2,
+         'message': 'validation issue',
+         'item': '{}/index.cnxml'.format(new_module.id),
+         'error': '5:920 -- error: unfinished element',
+         },
     ]
     assert resp.json['messages'] == expected_msgs
 


### PR DESCRIPTION
This adds content and identifier validation to the litezip publication view. It stops any invalid content from being added to the database. The response is similar to the response given when a litezip payload is not a valid zip file.

This also fixes the templates, which had validation issues in them due to empty tags that require children.