### PR TITLE
Integrate Sentry's Raven client

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -24,6 +24,15 @@ Configuration
    See also :ref:`configuration_chapter__logging` for information
    on how to configure logging.
 
+.. automodule:: press.raven
+   :members: includeme
+
+.. seealso::
+
+   See also :ref:`configuration_chapter__error_reporting` for information
+   on how to configure Sentry's Raven integration.
+
+
 Publishing
 ==========
 
@@ -67,3 +76,9 @@ Data Models
 
 .. automodule:: press.models
    :members:
+
+Tweens
+======
+
+.. automodule:: press.raven
+   :members: raven_tween_factory

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -21,6 +21,7 @@ Setting                          Env Variable            Required?
 ``shared_directory``             ``SHARED_DIR``          yes
 ``debug``                        ``DEBUG``               no
 ``logging.level``                ``DEBUG``               no
+``sentry.dsn``                   ``SENTRY_DSN``          no
 ===============================  ======================  =============
 
 See `cnx-db configuration docs
@@ -38,3 +39,12 @@ Logging
 The logging configuration is by default set to ``INFO`` level logging.
 If you wish to receive ``DEBUG`` level logging you should set the
 ``DEBUG`` environment variable to ``true``.
+
+Error Reporting
+---------------
+
+This application contains integration code to report errors
+to a `Sentry <https://sentry.io>`_ instance.
+The integration can be configured by supplying the ``SENTRY_DSN``,
+which is usually provided to you during your projects setup
+in the sentry software.

--- a/press/config.py
+++ b/press/config.py
@@ -44,12 +44,15 @@ def configure(settings=None):
     assert os.path.exists(settings['shared_directory'])  # required
     # TODO check permissions for write access
 
+    discover_set(settings, 'sentry.dsn', 'SENTRY_DSN')
+
     discover_set(settings, 'debug', 'DEBUG', False, asbool)
     settings['logging.level'] = settings['debug'] and 'DEBUG' or 'INFO'
 
     # Create the configuration object
     config = Configurator(settings=settings)
     config.include('.logging')
+    config.include('.raven')
     config.include('.views')
 
     with warnings.catch_warnings():

--- a/press/raven.py
+++ b/press/raven.py
@@ -1,0 +1,27 @@
+from pyramid import tweens
+import raven
+
+
+def raven_tween_factory(handler, registry):
+    client = raven.Client(registry.settings.get('sentry.dsn'))
+
+    def tween(request):
+        try:
+            response = handler(request)
+        except:  # noqa: E722
+            client.captureException()
+            raise  # raise to continue down the request pipeline
+        finally:
+            client.context.clear()
+        return response
+
+    return tween
+
+
+def includeme(config):
+    """Integrates Sentry's Raven client"""
+    config.add_tween(
+        'press.raven.raven_tween_factory',
+        under=tweens.INGRESS,
+        over=tweens.EXCVIEW,
+    )

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -10,4 +10,6 @@ pyramid==1.9.1
 
 pyramid_swagger==2.6.0
 
+raven
+
 structlog==18.1.0

--- a/tests/unit/test_raven.py
+++ b/tests/unit/test_raven.py
@@ -1,0 +1,87 @@
+import pretend
+import pytest
+from pyramid import tweens
+
+from press import raven
+
+
+class TestException(Exception):
+    """Used to invoke an exception within a request handler"""
+
+
+def test_tween_without_error(monkeypatch):
+    # Stub out the raven.Client calls
+    capture_exception = pretend.call_recorder(lambda: None)
+    context_clear = pretend.call_recorder(lambda: None)
+    client = pretend.stub(
+        captureException=capture_exception,
+        context=pretend.stub(clear=context_clear),
+    )
+    client_factory = pretend.call_recorder(lambda dsn: client)
+    monkeypatch.setattr(raven.raven, 'Client', client_factory)
+
+    # Stub out the calls to the registry
+    test_dsn = '<dsn>'
+    registry = pretend.stub(settings={'sentry.dsn': test_dsn})
+
+    @pretend.call_recorder
+    def handler(request):
+        pass
+
+    tween = raven.raven_tween_factory(handler, registry)
+
+    request = object()  # marker object
+    tween(request)
+
+    assert client_factory.calls == [pretend.call(test_dsn)]
+    assert capture_exception.calls == []
+    assert handler.calls == [pretend.call(request)]
+    assert context_clear.calls == [pretend.call()]
+
+
+def test_tween_with_error(monkeypatch):
+    # Stub out the raven.Client calls
+    capture_exception = pretend.call_recorder(lambda: None)
+    context_clear = pretend.call_recorder(lambda: None)
+    client = pretend.stub(
+        captureException=capture_exception,
+        context=pretend.stub(clear=context_clear),
+    )
+    client_factory = pretend.call_recorder(lambda dsn: client)
+    monkeypatch.setattr(raven.raven, 'Client', client_factory)
+
+    # Stub out the calls to the registry
+    test_dsn = '<dsn>'
+    registry = pretend.stub(settings={'sentry.dsn': test_dsn})
+
+    @pretend.call_recorder
+    def handler(request):
+        raise TestException
+
+    tween = raven.raven_tween_factory(handler, registry)
+
+    request = object()  # marker object
+    with pytest.raises(TestException):
+        tween(request)
+
+    assert client_factory.calls == [pretend.call(test_dsn)]
+    assert capture_exception.calls == [pretend.call()]
+    assert handler.calls == [pretend.call(request)]
+    assert context_clear.calls == [pretend.call()]
+
+
+def test_includeme():
+    # FIXME Need to do under and over
+    add_tween = pretend.call_recorder(lambda factory, over, under: None)
+    config = pretend.stub(add_tween=add_tween)
+
+    # Call the target includeme
+    raven.includeme(config)
+
+    assert config.add_tween.calls == [
+        pretend.call(
+            'press.raven.raven_tween_factory',
+            under=tweens.INGRESS,
+            over=tweens.EXCVIEW,
+        ),
+    ]


### PR DESCRIPTION
This will enable us to track errors in a Sentry instance.