### PR TITLE
Add a separate testing configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ help-test :
 	@echo "    (see also setup.cfg's pytest configuration)"
 
 test :
-	docker-compose run --rm web bin/test $(TEST_EXTRA_ARGS) $(TEST)
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm web bin/test $(TEST_EXTRA_ARGS) $(TEST)
 
 # /Test
 

--- a/bin/test
+++ b/bin/test
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-# Wait for the database to start up. The first time takes a little longer.
-until python -c "import os, psycopg2 as p; p.connect(os.environ['DB_URL'])"; do
+# Wait for a connection to start up. The first time takes a little longer.
+until python -c "import os, psycopg2 as p; dsn = os.environ['DB_SUPER_URL'].rsplit('/', 1)[0] + '/postgres';p.connect(dsn)"; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,10 @@
+version: '2'
+# extends docker-compose.yml
+# use `docker-compose -f docker-compose.yml -f docker-compose.test.yml ...`
+services:
+  web:
+    volumes:
+      - ./bin:/app/bin:z
+    environment:
+      - DB_URL=postgresql://rhaptos@db/testing
+      - DB_SUPER_URL=postgresql://rhaptos_admin@db/testing

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -5,6 +5,12 @@ Change Log
 ?.?.?
 -----
 
+- Adjust ``make test`` to use an extended docker-compose configuration.
+  Test runs should now use
+  ``docker-compose -f docker-compose.yml -f docker-compose.test.yml ...``.
+  This specifically enables the user to have a separate testing database
+  from the one the one used by the app running via ``make serve``.
+  See https://github.com/Connexions/cnx-press/pull/44
 - Remove temporary ``FIXME`` workaround for the missing 'cnxorg' namespace
   by installing ``cnx-litezip==1.3.1``.
   See https://github.com/Connexions/cnx-press/pull/43


### PR DESCRIPTION
This separates the testing configuration into a different docker-compose
file that extends the base file. This specifically mounts the bin directory
and more importantly assigns a 'testing' database separate from the base
database, 'repository'.

This allows one to have a functional database that maintains its data
regardless of test runs. Previously, we would wipe the database before
a test run.

Closes #34 