### PR TITLE
On publish assign major_version rather than version

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -5,6 +5,10 @@ Change Log
 ?.?.?
 -----
 
+- On publish assign ``major_version`` rather than ``version`` to prevent
+  the database triggers that deal with legacy content from manipulating
+  the record and invoking revision publications.
+  See https://github.com/Connexions/cnx-press/issues/53
 - Fix issue parsing abstracts that contain cnxml.
 - Adjust ``make test`` to use an extended docker-compose configuration.
   Test runs should now use

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -37,8 +37,7 @@ def publish_legacy_book(model, metadata, submission, registry):
             .limit(1))
         # At this time, this code assumes an existing module
         existing_module = result.fetchone()
-        version = tuple(int(x) for x in existing_module.version.split('.'))
-        version = '.'.join([str(version[0]), str(version[1] + 1)])
+        major_version = existing_module.major_version + 1
 
         # Insert module metadata
         result = trans.execute(t.abstracts.insert()
@@ -50,7 +49,7 @@ def publish_legacy_book(model, metadata, submission, registry):
         licenseid = result.fetchone().licenseid
         result = trans.execute(t.modules.insert().values(
             moduleid=metadata.id,
-            version=version,
+            major_version=major_version,
             portal_type='Collection',
             name=metadata.title,
             created=metadata.created,

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -35,8 +35,7 @@ def publish_legacy_page(model, metadata, submission, registry):
             .where(t.latest_modules.c.moduleid == metadata.id))
         # At this time, this code assumes an existing module
         existing_module = result.fetchone()
-        version = tuple(int(x) for x in existing_module.version.split('.'))
-        version = '.'.join([str(version[0]), str(version[1] + 1)])
+        major_version = existing_module.major_version + 1
 
         # Insert module metadata
         result = trans.execute(t.abstracts.insert()
@@ -48,7 +47,7 @@ def publish_legacy_page(model, metadata, submission, registry):
         licenseid = result.fetchone().licenseid
         result = trans.execute(t.modules.insert().values(
             moduleid=metadata.id,
-            version=version,
+            major_version=major_version,
             portal_type='Module',
             name=metadata.title,
             created=metadata.created,

--- a/tests/unit/legacy_publishing/test_collection.py
+++ b/tests/unit/legacy_publishing/test_collection.py
@@ -43,6 +43,8 @@ def test_publish_legacy_book(
             .select()
             .where(db_tables.modules.c.module_ident == ident))
     result = db_engines['common'].execute(stmt).fetchone()
+    assert result.major_version == 2
+    assert result.minor_version == 1
     assert result.version == '1.2'
     assert result.abstract == metadata.abstract
     assert result.created == parse_date(metadata.created)

--- a/tests/unit/legacy_publishing/test_module.py
+++ b/tests/unit/legacy_publishing/test_module.py
@@ -26,6 +26,8 @@ def test_publish_revision_to_legacy_page(
             .where(db_tables.modules.c.module_ident == ident))
     result = db_engines['common'].execute(stmt).fetchone()
     assert result.version == '1.2'
+    assert result.major_version == 2
+    assert result.minor_version is None
     assert result.abstract == metadata.abstract
     assert result.created == parse_date(metadata.created)
     assert result.revised == parse_date(metadata.revised)


### PR DESCRIPTION
On publish assign ``major_version`` rather than ``version`` to prevent
he database triggers that deal with legacy content from manipulating
the record and invoking revision publications.

Addresses #53 