### PR TITLE
Move the database connection init

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -5,6 +5,8 @@ Change Log
 ?.?.?
 -----
 
+- Move the database connection creation into the publishing view code
+  so that a single transaction can be pushed down through the functions.
 - Refactor the testing persistence utility. And correct the versioning usage
   similar to what previous changes addressed except in the testing code.
 - On publish assign ``major_version`` rather than ``version`` to prevent

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -1,3 +1,4 @@
+from pyramid.threadlocal import get_current_registry
 from sqlalchemy.sql import text
 
 from .utils import replace_id_and_version
@@ -8,7 +9,7 @@ __all__ = (
 )
 
 
-def publish_legacy_book(model, metadata, submission, registry):
+def publish_legacy_book(model, metadata, submission, db_conn):
     """Publish a Book (aka Collection) as the legacy (zope-based) system
     would.
 
@@ -18,99 +19,97 @@ def publish_legacy_book(model, metadata, submission, registry):
     :param submission: a two value tuple containing a userid
                        and submit message
     :type submission: tuple
-    :param registry: the pyramid component architecture registry
-    :type registry: :class:`pyramid.registry.Registry`
+    :param db_conn: a database connection object
+    :type db_conn: :class:`sqlalchemy.engine.Connection`
 
     """
-    engine = registry.engines['common']
-    t = registry.tables
+    t = get_current_registry().tables
 
     if model.id is None or metadata.id is None:  # pragma: no cover
         raise NotImplementedError()
 
-    with engine.begin() as trans:
-        result = trans.execute(
-            t.modules.select()
-            .where(t.modules.c.moduleid == metadata.id)
-            .order_by(t.modules.c.major_version.desc())
-            .limit(1))
-        # At this time, this code assumes an existing module
-        existing_module = result.fetchone()
-        major_version = existing_module.major_version + 1
+    result = db_conn.execute(
+        t.modules.select()
+        .where(t.modules.c.moduleid == metadata.id)
+        .order_by(t.modules.c.major_version.desc())
+        .limit(1))
+    # At this time, this code assumes an existing module
+    existing_module = result.fetchone()
+    major_version = existing_module.major_version + 1
 
-        # Insert module metadata
-        result = trans.execute(t.abstracts.insert()
-                               .values(abstract=metadata.abstract))
-        abstractid = result.inserted_primary_key[0]
-        result = trans.execute(
-            t.licenses.select()
-            .where(t.licenses.c.url == metadata.license_url))
-        licenseid = result.fetchone().licenseid
-        result = trans.execute(t.modules.insert().values(
-            moduleid=metadata.id,
-            major_version=major_version,
-            portal_type='Collection',
-            name=metadata.title,
-            created=metadata.created,
-            revised=metadata.revised,
-            abstractid=abstractid,
-            licenseid=licenseid,
-            doctype='',
-            submitter=submission[0],
-            submitlog=submission[1],
-            language=metadata.language,
-            authors=metadata.authors,
-            maintainers=metadata.maintainers,
-            licensors=metadata.licensors,
-            # TODO metadata does not currently capture parentage
-            parent=None,
-            parentauthors=None,
-        ).returning(
-            t.modules.c.module_ident,
-            t.modules.c.moduleid,
-            t.modules.c.version,
+    # Insert module metadata
+    result = db_conn.execute(t.abstracts.insert()
+                             .values(abstract=metadata.abstract))
+    abstractid = result.inserted_primary_key[0]
+    result = db_conn.execute(
+        t.licenses.select()
+        .where(t.licenses.c.url == metadata.license_url))
+    licenseid = result.fetchone().licenseid
+    result = db_conn.execute(t.modules.insert().values(
+        moduleid=metadata.id,
+        major_version=major_version,
+        portal_type='Collection',
+        name=metadata.title,
+        created=metadata.created,
+        revised=metadata.revised,
+        abstractid=abstractid,
+        licenseid=licenseid,
+        doctype='',
+        submitter=submission[0],
+        submitlog=submission[1],
+        language=metadata.language,
+        authors=metadata.authors,
+        maintainers=metadata.maintainers,
+        licensors=metadata.licensors,
+        # TODO metadata does not currently capture parentage
+        parent=None,
+        parentauthors=None,
+    ).returning(
+        t.modules.c.module_ident,
+        t.modules.c.moduleid,
+        t.modules.c.version,
+    ))
+    ident, id, version = result.fetchone()
+
+    # Insert subjects metadata
+    stmt = (text('INSERT INTO moduletags '
+                 'SELECT :module_ident AS module_ident, tagid '
+                 'FROM tags WHERE tag = any(:subjects)')
+            .bindparams(module_ident=ident,
+                        subjects=list(metadata.subjects)))
+    result = db_conn.execute(stmt)
+
+    # Insert keywords metadata
+    stmt = (text('INSERT INTO keywords (word) '
+                 'SELECT iword AS word '
+                 'FROM unnest(:keywords ::text[]) AS iword '
+                 '     LEFT JOIN keywords AS kw ON (kw.word = iword) '
+                 'WHERE kw.keywordid IS NULL')
+            .bindparams(keywords=list(metadata.keywords)))
+    db_conn.execute(stmt)
+    stmt = (text('INSERT INTO modulekeywords '
+                 'SELECT :module_ident AS module_ident, keywordid '
+                 'FROM keywords WHERE word = any(:keywords)')
+            .bindparams(module_ident=ident,
+                        keywords=list(metadata.keywords)))
+    db_conn.execute(stmt)
+
+    # Rewrite the content with the id and version
+    replace_id_and_version(model, id, version)
+
+    # Insert module files (content and resources)
+    with model.file.open('rb') as fb:
+        result = db_conn.execute(t.files.insert().values(
+            file=fb.read(),
+            media_type='text/xml',
         ))
-        ident, id, version = result.fetchone()
+    fileid = result.inserted_primary_key[0]
+    result = db_conn.execute(t.module_files.insert().values(
+        module_ident=ident,
+        fileid=fileid,
+        filename='collection.xml',
+    ))
 
-        # Insert subjects metadata
-        stmt = (text('INSERT INTO moduletags '
-                     'SELECT :module_ident AS module_ident, tagid '
-                     'FROM tags WHERE tag = any(:subjects)')
-                .bindparams(module_ident=ident,
-                            subjects=list(metadata.subjects)))
-        result = trans.execute(stmt)
-
-        # Insert keywords metadata
-        stmt = (text('INSERT INTO keywords (word) '
-                     'SELECT iword AS word '
-                     'FROM unnest(:keywords ::text[]) AS iword '
-                     '     LEFT JOIN keywords AS kw ON (kw.word = iword) '
-                     'WHERE kw.keywordid IS NULL')
-                .bindparams(keywords=list(metadata.keywords)))
-        trans.execute(stmt)
-        stmt = (text('INSERT INTO modulekeywords '
-                     'SELECT :module_ident AS module_ident, keywordid '
-                     'FROM keywords WHERE word = any(:keywords)')
-                .bindparams(module_ident=ident,
-                            keywords=list(metadata.keywords)))
-        trans.execute(stmt)
-
-        # Rewrite the content with the id and version
-        replace_id_and_version(model, id, version)
-
-        # Insert module files (content and resources)
-        with model.file.open('rb') as fb:
-            result = trans.execute(t.files.insert().values(
-                file=fb.read(),
-                media_type='text/xml',
-            ))
-        fileid = result.inserted_primary_key[0]
-        result = trans.execute(t.module_files.insert().values(
-            module_ident=ident,
-            fileid=fileid,
-            filename='collection.xml',
-        ))
-
-        # TODO Insert resource files (cover image, recipe, etc.)
+    # TODO Insert resource files (cover image, recipe, etc.)
 
     return (id, version), ident

--- a/press/legacy_publishing/litezip.py
+++ b/press/legacy_publishing/litezip.py
@@ -14,7 +14,7 @@ __all__ = (
 )
 
 
-def publish_litezip(struct, submission, registry):
+def publish_litezip(struct, submission, db_conn):
     """Publish the contents of a litezip structured set of data.
 
     :param struct: a litezip struct from (probably from
@@ -22,8 +22,8 @@ def publish_litezip(struct, submission, registry):
     :param submission: a two value tuple containing a userid
                        and submit message
     :type submission: tuple
-    :param registry: the pyramid component architecture registry
-    :type registry: :class:`pyramid.registry.Registry`
+    :param db_conn: a database connection object
+    :type db_conn: :class:`sqlalchemy.engine.Connection`
 
     """
     # Dissect objects from litezip struct.
@@ -42,7 +42,7 @@ def publish_litezip(struct, submission, registry):
         metadata = parse_module_metadata(module)
         old_id = module.id
         (id, version), ident = publish_legacy_page(module, metadata,
-                                                   submission, registry)
+                                                   submission, db_conn)
         id_map[old_id] = (id, version)
         # Update the Collection tree
         xpath = '//col:module[@document="{}"]'.format(old_id)
@@ -61,7 +61,7 @@ def publish_litezip(struct, submission, registry):
     metadata = parse_collection_metadata(collection)
     old_id = collection.id
     (id, version), ident = publish_legacy_book(collection, metadata,
-                                               submission, registry)
+                                               submission, db_conn)
     id_map[old_id] = (id, version)
 
     return id_map

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -1,3 +1,4 @@
+from pyramid.threadlocal import get_current_registry
 from sqlalchemy.sql import text
 
 from .utils import replace_id_and_version
@@ -8,7 +9,7 @@ __all__ = (
 )
 
 
-def publish_legacy_page(model, metadata, submission, registry):
+def publish_legacy_page(model, metadata, submission, db_conn):
     """Publish a Page (aka Module) as the legacy (zope-based) system
     would.
 
@@ -18,97 +19,95 @@ def publish_legacy_page(model, metadata, submission, registry):
     :param submission: a two value tuple containing a userid
                        and submit message
     :type submission: tuple
-    :param registry: the pyramid component architecture registry
-    :type registry: :class:`pyramid.registry.Registry`
+    :param db_conn: a database connection object
+    :type db_conn: :class:`sqlalchemy.engine.Connection`
 
     """
-    engine = registry.engines['common']
-    t = registry.tables
+    t = get_current_registry().tables
 
     if model.id is None or metadata.id is None:  # pragma: no cover
         raise NotImplementedError()
 
-    with engine.begin() as trans:
-        result = trans.execute(
-            t.latest_modules.select()
-            .where(t.latest_modules.c.moduleid == metadata.id))
-        # At this time, this code assumes an existing module
-        existing_module = result.fetchone()
-        major_version = existing_module.major_version + 1
+    result = db_conn.execute(
+        t.latest_modules.select()
+        .where(t.latest_modules.c.moduleid == metadata.id))
+    # At this time, this code assumes an existing module
+    existing_module = result.fetchone()
+    major_version = existing_module.major_version + 1
 
-        # Insert module metadata
-        result = trans.execute(t.abstracts.insert()
-                               .values(abstract=metadata.abstract))
-        abstractid = result.inserted_primary_key[0]
-        result = trans.execute(
-            t.licenses.select()
-            .where(t.licenses.c.url == metadata.license_url))
-        licenseid = result.fetchone().licenseid
-        result = trans.execute(t.modules.insert().values(
-            moduleid=metadata.id,
-            major_version=major_version,
-            portal_type='Module',
-            name=metadata.title,
-            created=metadata.created,
-            revised=metadata.revised,
-            abstractid=abstractid,
-            licenseid=licenseid,
-            doctype='',
-            submitter=submission[0],
-            submitlog=submission[1],
-            language=metadata.language,
-            authors=metadata.authors,
-            maintainers=metadata.maintainers,
-            licensors=metadata.licensors,
-            # TODO metadata does not currently capture parentage
-            parent=None,
-            parentauthors=None,
-        ).returning(
-            t.modules.c.module_ident,
-            t.modules.c.moduleid,
-            t.modules.c.version,
+    # Insert module metadata
+    result = db_conn.execute(t.abstracts.insert()
+                             .values(abstract=metadata.abstract))
+    abstractid = result.inserted_primary_key[0]
+    result = db_conn.execute(
+        t.licenses.select()
+        .where(t.licenses.c.url == metadata.license_url))
+    licenseid = result.fetchone().licenseid
+    result = db_conn.execute(t.modules.insert().values(
+        moduleid=metadata.id,
+        major_version=major_version,
+        portal_type='Module',
+        name=metadata.title,
+        created=metadata.created,
+        revised=metadata.revised,
+        abstractid=abstractid,
+        licenseid=licenseid,
+        doctype='',
+        submitter=submission[0],
+        submitlog=submission[1],
+        language=metadata.language,
+        authors=metadata.authors,
+        maintainers=metadata.maintainers,
+        licensors=metadata.licensors,
+        # TODO metadata does not currently capture parentage
+        parent=None,
+        parentauthors=None,
+    ).returning(
+        t.modules.c.module_ident,
+        t.modules.c.moduleid,
+        t.modules.c.version,
+    ))
+    ident, id, version = result.fetchone()
+
+    # Insert subjects metadata
+    stmt = (text('INSERT INTO moduletags '
+                 'SELECT :module_ident AS module_ident, tagid '
+                 'FROM tags WHERE tag = any(:subjects)')
+            .bindparams(module_ident=ident,
+                        subjects=list(metadata.subjects)))
+    result = db_conn.execute(stmt)
+
+    # Insert keywords metadata
+    stmt = (text('INSERT INTO keywords (word) '
+                 'SELECT iword AS word '
+                 'FROM unnest(:keywords ::text[]) AS iword '
+                 '     LEFT JOIN keywords AS kw ON (kw.word = iword) '
+                 'WHERE kw.keywordid IS NULL')
+            .bindparams(keywords=list(metadata.keywords)))
+    db_conn.execute(stmt)
+    stmt = (text('INSERT INTO modulekeywords '
+                 'SELECT :module_ident AS module_ident, keywordid '
+                 'FROM keywords WHERE word = any(:keywords)')
+            .bindparams(module_ident=ident,
+                        keywords=list(metadata.keywords)))
+    db_conn.execute(stmt)
+
+    # Rewrite the content with the id and version
+    replace_id_and_version(model, id, version)
+
+    # Insert module files (content and resources)
+    with model.file.open('rb') as fb:
+        result = db_conn.execute(t.files.insert().values(
+            file=fb.read(),
+            media_type='text/xml',
         ))
-        ident, id, version = result.fetchone()
+    fileid = result.inserted_primary_key[0]
+    result = db_conn.execute(t.module_files.insert().values(
+        module_ident=ident,
+        fileid=fileid,
+        filename='index.cnxml',
+    ))
 
-        # Insert subjects metadata
-        stmt = (text('INSERT INTO moduletags '
-                     'SELECT :module_ident AS module_ident, tagid '
-                     'FROM tags WHERE tag = any(:subjects)')
-                .bindparams(module_ident=ident,
-                            subjects=list(metadata.subjects)))
-        result = trans.execute(stmt)
-
-        # Insert keywords metadata
-        stmt = (text('INSERT INTO keywords (word) '
-                     'SELECT iword AS word '
-                     'FROM unnest(:keywords ::text[]) AS iword '
-                     '     LEFT JOIN keywords AS kw ON (kw.word = iword) '
-                     'WHERE kw.keywordid IS NULL')
-                .bindparams(keywords=list(metadata.keywords)))
-        trans.execute(stmt)
-        stmt = (text('INSERT INTO modulekeywords '
-                     'SELECT :module_ident AS module_ident, keywordid '
-                     'FROM keywords WHERE word = any(:keywords)')
-                .bindparams(module_ident=ident,
-                            keywords=list(metadata.keywords)))
-        trans.execute(stmt)
-
-        # Rewrite the content with the id and version
-        replace_id_and_version(model, id, version)
-
-        # Insert module files (content and resources)
-        with model.file.open('rb') as fb:
-            result = trans.execute(t.files.insert().values(
-                file=fb.read(),
-                media_type='text/xml',
-            ))
-        fileid = result.inserted_primary_key[0]
-        result = trans.execute(t.module_files.insert().values(
-            module_ident=ident,
-            fileid=fileid,
-            filename='index.cnxml',
-        ))
-
-        # TODO Insert resource files (images, pdfs, etc.)
+    # TODO Insert resource files (images, pdfs, etc.)
 
     return (id, version), ident

--- a/press/views/legacy_publishing.py
+++ b/press/views/legacy_publishing.py
@@ -56,8 +56,9 @@ def publish(request):
             for path, message in validation_msgs
         ]}
 
-    id_mapping = publish_litezip(litezip_struct, (publisher, message),
-                                 request.registry)
+    with request.registry.engines['common'].begin() as db_conn:
+        id_mapping = publish_litezip(litezip_struct, (publisher, message),
+                                     db_conn)
 
     resp_data = []
     for src_id, (id, ver) in id_mapping.items():

--- a/tests/unit/legacy_publishing/test_collection.py
+++ b/tests/unit/legacy_publishing/test_collection.py
@@ -33,10 +33,13 @@ def test_publish_legacy_book(
     collection, tree, modules = content_util.rebuild_collection(collection,
                                                                 tree)
 
-    registry = app.registry
-    (id, version), ident = publish_legacy_book(collection, metadata,
-                                               ('user1', 'test publish',),
-                                               registry)
+    with db_engines['common'].begin() as conn:
+        (id, version), ident = publish_legacy_book(
+            collection,
+            metadata,
+            ('user1', 'test publish',),
+            conn,
+        )
 
     # Check core metadata insertion
     stmt = (db_tables.modules.join(db_tables.abstracts)

--- a/tests/unit/legacy_publishing/test_litezip.py
+++ b/tests/unit/legacy_publishing/test_litezip.py
@@ -29,8 +29,13 @@ def test_publish_litezip(
                                                                 tree)
     struct = tuple([collection, new_module])
 
-    registry = app.registry
-    id_map = publish_litezip(struct, ('user1', 'test publish',), registry)
+    with db_engines['common'].begin() as conn:
+        id_map = publish_litezip(
+            struct,
+            ('user1', 'test publish',),
+            conn,
+        )
+
     expected_id_map = {
         new_module.id: (new_module.id, '1.2'),
         collection.id: (collection.id, '1.2'),

--- a/tests/unit/legacy_publishing/test_module.py
+++ b/tests/unit/legacy_publishing/test_module.py
@@ -15,10 +15,13 @@ def test_publish_revision_to_legacy_page(
 
     metadata = parse_module_metadata(module)
 
-    registry = app.registry
-    (id, version), ident = publish_legacy_page(module, metadata,
-                                               ('user1', 'test publish',),
-                                               registry)
+    with db_engines['common'].begin() as conn:
+        (id, version), ident = publish_legacy_page(
+            module,
+            metadata,
+            ('user1', 'test publish',),
+            conn,
+        )
 
     # Check core metadata insertion
     stmt = (db_tables.modules.join(db_tables.abstracts)


### PR DESCRIPTION
Move the database connection creation into the publishing view code
so that a single transaction can be pushed down through the functions.

This indirectly works towards #53 by enabling a top-level transaction that can encompass both the publication and republications.