### PR TITLE
Correct missing resource links on revision publication

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -5,6 +5,9 @@ Change Log
 ?.?.X
 -----
 
+- Fix issue with published content missing resources. This was because we
+  don't link the previous versions resources to the newly published version.
+  See https://github.com/Connexions/nebuchadnezzar/issues/23
 - Fix publication insertion to use the existing UUID for content rather
   than create a new UUID.
   See https://github.com/Connexions/cnx-press/issues/75

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -113,4 +113,20 @@ def publish_legacy_book(model, metadata, submission, db_conn):
 
     # TODO Insert resource files (cover image, recipe, etc.)
 
+    # Copy over existing module_files entries
+    stmt = text(
+        'INSERT INTO module_files '
+        'SELECT :module_ident, fileid, filename '
+        'FROM module_files '
+        'WHERE module_ident = :previous_module_ident '
+        '      AND filename NOT IN (SELECT filename '
+        '                           FROM module_files '
+        '                           WHERE module_ident = :module_ident)'
+    )
+    db_conn.execute(
+        stmt,
+        module_ident=ident,
+        previous_module_ident=existing_module.module_ident,
+    )
+
     return (id, version), ident

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -112,4 +112,20 @@ def publish_legacy_page(model, metadata, submission, db_conn):
 
     # TODO Insert resource files (images, pdfs, etc.)
 
+    # Copy over existing module_files entries
+    stmt = text(
+        'INSERT INTO module_files '
+        'SELECT :module_ident, fileid, filename '
+        'FROM module_files '
+        'WHERE module_ident = :previous_module_ident '
+        '      AND filename NOT IN (SELECT filename '
+        '                           FROM module_files '
+        '                           WHERE module_ident = :module_ident)'
+    )
+    db_conn.execute(
+        stmt,
+        module_ident=ident,
+        previous_module_ident=existing_module.module_ident,
+    )
+
     return (id, version), ident

--- a/press/models.py
+++ b/press/models.py
@@ -9,7 +9,7 @@ CollectionMetadata = namedtuple(
     ('id version created revised title '
      'license_url language print_style '
      'authors maintainers licensors '
-     'keywords subjects abstract')
+     'keywords subjects abstract'),
 )
 
 ModuleMetadata = namedtuple(
@@ -17,5 +17,11 @@ ModuleMetadata = namedtuple(
     ('id version created revised title '
      'license_url language '
      'authors maintainers licensors '
-     'keywords subjects abstract')
+     'keywords subjects abstract'),
+)
+
+
+Resource = namedtuple(
+    'Resource',
+    ('data filename media_type sha1'),
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -524,25 +524,33 @@ class _PersistUtil:
             .where(t.licenses.c.url == metadata.license_url))
         licenseid = result.fetchone().licenseid
         major_version = metadata.version.split('.')[-1]
-        result = trans.execute(t.modules.insert().values(
-            moduleid=metadata.id,
-            major_version=major_version,
-            portal_type=type_,
-            name=metadata.title,
-            created=metadata.created,
-            revised=metadata.revised,
-            abstractid=abstractid,
-            licenseid=licenseid,
-            doctype='',
-            submitter='user1',
-            submitlog='util inserted',
-            language=metadata.language,
-            authors=metadata.authors,
-            maintainers=metadata.maintainers,
-            licensors=metadata.licensors,
-            parent=None,
-            parentauthors=None,
-        ).returning(t.modules.c.module_ident, t.modules.c.moduleid))
+        existing_metadata = trans.execute(
+            t.modules.select().where(t.modules.c.moduleid == metadata.id)
+        ).fetchone()
+        existing_uuid = existing_metadata and existing_metadata.uuid or None
+
+        result = trans.execute(
+            t.modules.insert().values(
+                uuid=existing_uuid,
+                moduleid=metadata.id,
+                major_version=major_version,
+                portal_type=type_,
+                name=metadata.title,
+                created=metadata.created,
+                revised=metadata.revised,
+                abstractid=abstractid,
+                licenseid=licenseid,
+                doctype='',
+                submitter='user1',
+                submitlog='util inserted',
+                language=metadata.language,
+                authors=metadata.authors,
+                maintainers=metadata.maintainers,
+                licensors=metadata.licensors,
+                parent=None,
+                parentauthors=None,
+            ).returning(t.modules.c.module_ident, t.modules.c.moduleid)
+        )
         ident, id = result.fetchone()
 
         # Insert subjects metadata

--- a/tests/functional/legacy_publishing/test_collection.py
+++ b/tests/functional/legacy_publishing/test_collection.py
@@ -16,7 +16,10 @@ from tests.helpers import (
 def test_publish_legacy_book(
         content_util, persist_util, app, db_engines, db_tables):
     # Insert initial collection and modules.
-    collection, tree, modules = content_util.gen_collection()
+    resources = list([content_util.gen_resource() for x in range(0, 2)])
+    collection, tree, modules = content_util.gen_collection(
+        resources=resources
+    )
     modules = list([persist_util.insert_module(m) for m in modules])
     collection, tree, modules = content_util.rebuild_collection(collection,
                                                                 tree)
@@ -94,9 +97,12 @@ def test_publish_legacy_book(
             .where(db_tables.module_files.c.module_ident == ident))
     result = db_engines['common'].execute(stmt).fetchall()
     filenames = [x.filename for x in result]
+    assert len(filenames) == len(resources) + 1  # content file
     assert 'collection.xml' in filenames
 
-    # TODO Check for resource file insertion
+    # Check for resource file insertion
+    for resource in resources:
+        assert resource.filename in filenames
 
     # Check the tree for accuracy (even though this is out of scope)
     stmt = (

--- a/tests/functional/legacy_publishing/test_module.py
+++ b/tests/functional/legacy_publishing/test_module.py
@@ -10,7 +10,8 @@ from press.parsers import (
 
 def test_publish_revision_to_legacy_page(
         content_util, persist_util, app, db_engines, db_tables):
-    module = content_util.gen_module()
+    resources = list([content_util.gen_resource() for x in range(0, 2)])
+    module = content_util.gen_module(resources=resources)
     module = persist_util.insert_module(module)
 
     metadata = parse_module_metadata(module)
@@ -76,7 +77,9 @@ def test_publish_revision_to_legacy_page(
             .where(db_tables.module_files.c.module_ident == ident))
     result = db_engines['common'].execute(stmt).fetchall()
     filenames = [x.filename for x in result]
+    assert len(filenames) == len(resources) + 2  # content files
     assert 'index.cnxml' in filenames
     assert 'index.cnxml.html' in filenames
-
-    # TODO Check for resource file insertion
+    # Check for resource file insertion
+    for resource in resources:
+        assert resource.filename in filenames


### PR DESCRIPTION
This corrects the issue with missing resource files after publish.
The resource files are now copied from the previous version.

Depends on #76 

Addresses Connexions/nebuchadnezzar#23