### PR TITLE
Fix publication revised time to use database default column value

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,14 @@
 Change Log
 ==========
 
+?.?.X
+-----
+
+- Let the database set the revised content timestamp, which is associated
+  with when the last publish was made.
+  See https://github.com/Connexions/cnx-press/issues/81 &
+  https://github.com/Connexions/nebuchadnezzar/issues/35
+
 2.0.1
 -----
 

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -52,7 +52,6 @@ def publish_legacy_book(model, metadata, submission, db_conn):
         portal_type='Collection',
         name=metadata.title,
         created=metadata.created,
-        revised=metadata.revised,
         abstractid=abstractid,
         licenseid=licenseid,
         doctype='',

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -51,7 +51,6 @@ def publish_legacy_page(model, metadata, submission, db_conn):
         portal_type='Module',
         name=metadata.title,
         created=metadata.created,
-        revised=metadata.revised,
         abstractid=abstractid,
         licenseid=licenseid,
         doctype='',

--- a/tests/functional/legacy_publishing/test_collection.py
+++ b/tests/functional/legacy_publishing/test_collection.py
@@ -1,7 +1,4 @@
-from datetime import datetime, timedelta
-
 from dateutil.parser import parse as parse_date
-from dateutil.utils import default_tzinfo
 from sqlalchemy.sql import text
 
 from press.legacy_publishing.collection import (
@@ -47,6 +44,7 @@ def test_publish_legacy_book(
                                                                 tree)
 
     with db_engines['common'].begin() as conn:
+        now = conn.execute('SELECT CURRENT_TIMESTAMP as now').fetchone().now
         (id, version), ident = publish_legacy_book(
             collection,
             metadata,
@@ -67,8 +65,7 @@ def test_publish_legacy_book(
     assert result.version == '1.2'
     assert result.abstract == metadata.abstract
     assert result.created == parse_date(metadata.created)
-    now = default_tzinfo(datetime.now(), result.revised.tzinfo)
-    assert (now - result.revised) < timedelta(minutes=1)
+    assert result.revised == now
     assert result.portal_type == 'Collection'
     assert result.name == metadata.title
     assert result.licenseid == 13

--- a/tests/functional/legacy_publishing/test_collection.py
+++ b/tests/functional/legacy_publishing/test_collection.py
@@ -1,4 +1,7 @@
+from datetime import datetime, timedelta
+
 from dateutil.parser import parse as parse_date
+from dateutil.utils import default_tzinfo
 from sqlalchemy.sql import text
 
 from press.legacy_publishing.collection import (
@@ -64,7 +67,8 @@ def test_publish_legacy_book(
     assert result.version == '1.2'
     assert result.abstract == metadata.abstract
     assert result.created == parse_date(metadata.created)
-    assert result.revised == parse_date(metadata.revised)
+    now = default_tzinfo(datetime.now(), result.revised.tzinfo)
+    assert (now - result.revised) < timedelta(minutes=1)
     assert result.portal_type == 'Collection'
     assert result.name == metadata.title
     assert result.licenseid == 13

--- a/tests/functional/legacy_publishing/test_module.py
+++ b/tests/functional/legacy_publishing/test_module.py
@@ -1,4 +1,7 @@
+from datetime import datetime, timedelta
+
 from dateutil.parser import parse as parse_date
+from dateutil.utils import default_tzinfo
 
 from press.legacy_publishing.module import (
     publish_legacy_page,
@@ -44,7 +47,8 @@ def test_publish_revision_to_legacy_page(
     assert result.minor_version is None
     assert result.abstract == metadata.abstract
     assert result.created == parse_date(metadata.created)
-    assert result.revised == parse_date(metadata.revised)
+    now = default_tzinfo(datetime.now(), result.revised.tzinfo)
+    assert (now - result.revised) < timedelta(minutes=1)
     assert result.portal_type == 'Module'
     assert result.name == metadata.title
     assert result.licenseid == 13

--- a/tests/functional/legacy_publishing/test_module.py
+++ b/tests/functional/legacy_publishing/test_module.py
@@ -1,7 +1,4 @@
-from datetime import datetime, timedelta
-
 from dateutil.parser import parse as parse_date
-from dateutil.utils import default_tzinfo
 
 from press.legacy_publishing.module import (
     publish_legacy_page,
@@ -27,6 +24,7 @@ def test_publish_revision_to_legacy_page(
     control_metadata = db_engines['common'].execute(stmt).fetchone()
 
     with db_engines['common'].begin() as conn:
+        now = conn.execute('SELECT CURRENT_TIMESTAMP as now').fetchone().now
         (id, version), ident = publish_legacy_page(
             module,
             metadata,
@@ -47,8 +45,7 @@ def test_publish_revision_to_legacy_page(
     assert result.minor_version is None
     assert result.abstract == metadata.abstract
     assert result.created == parse_date(metadata.created)
-    now = default_tzinfo(datetime.now(), result.revised.tzinfo)
-    assert (now - result.revised) < timedelta(minutes=1)
+    assert result.revised == now
     assert result.portal_type == 'Module'
     assert result.name == metadata.title
     assert result.licenseid == 13


### PR DESCRIPTION
This basically removes the line that inserts the revised datetime. We were previously taking this value from the submitted content. Now we are letting the database default to using the current time.

Fixes #81
Fixes Connexions/nebuchadnezzar#35
