### PR TITLE
Add before and after events to the legacy publishing request

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,6 +27,15 @@ Configuration
 Publishing
 ==========
 
+Events
+------
+
+.. autoclass:: press.events.LegacyPublicationStarted
+   :members:
+
+.. autoclass:: press.events.LegacyPublicationFinished
+   :members:
+
 :mod:`press.publishing`
 -----------------------
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,12 @@
 Change Log
 ==========
 
+?.?.?
+-----
+
+- Add events to legacy publications. This enables other subscriber code
+  to hook into these events.
+
 3.0.0
 -----
 

--- a/press/events.py
+++ b/press/events.py
@@ -1,0 +1,24 @@
+
+class LegacyPublicationStarted:
+    """Happens when a legacy publication has started
+
+    :param models: a sequence of litezip models to be published
+    :type models: sequence
+
+    """
+
+    def __init__(self, models):
+        self.models = models
+
+
+class LegacyPublicationFinished:
+    """Happens when a legacy publication has finished
+
+    :param ids: a pairing of moduleid and major & minor version
+    :type models: sequence of tuples containing the module and a sequence
+                  of the major and minor version
+
+    """
+
+    def __init__(self, ids):
+        self.ids = ids


### PR DESCRIPTION
Adds before and after events that other code can subscribe to. This may need to be modified, but it's a good first stab.

This will be used as the foundation work for addressing https://github.com/Connexions/nebuchadnezzar/issues/44 and likely many things to come.