### PR TITLE
Enqueue for export builds when the publication has finished

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -8,6 +8,9 @@ Change Log
 - Add events to legacy publications. This enables other subscriber code
   to hook into these events.
 
+- Add the raven client as a request method. This allows non-critical error
+  handling to report issues without bubbling it up through the main process.
+
 3.0.0
 -----
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -11,6 +11,11 @@ Change Log
 - Add the raven client as a request method. This allows non-critical error
   handling to report issues without bubbling it up through the main process.
 
+- Add publication finished event subscriber that contacts the legacy
+  service to enqueue the content for export file builds (i.e. completezip,
+  collxml, module export).
+  See https://github.com/Connexions/nebuchadnezzar/issues/44
+
 3.0.0
 -----
 

--- a/press/config.py
+++ b/press/config.py
@@ -53,6 +53,7 @@ def configure(settings=None):
     config = Configurator(settings=settings)
     config.include('.logging')
     config.include('.raven')
+    config.include('.subscribers')
     config.include('.views')
 
     with warnings.catch_warnings():

--- a/press/events.py
+++ b/press/events.py
@@ -4,21 +4,27 @@ class LegacyPublicationStarted:
 
     :param models: a sequence of litezip models to be published
     :type models: sequence
+    :param request: the request object
+    :type request: :class:`pyramid.request.Request`
 
     """
 
-    def __init__(self, models):
+    def __init__(self, models, request):
         self.models = models
+        self.request = request
 
 
 class LegacyPublicationFinished:
     """Happens when a legacy publication has finished
 
     :param ids: a pairing of moduleid and major & minor version
-    :type models: sequence of tuples containing the module and a sequence
-                  of the major and minor version
+    :type ids: sequence of tuples containing the module and a sequence
+               of the major and minor version
+    :param request: the request object
+    :type request: :class:`pyramid.request.Request`
 
     """
 
-    def __init__(self, ids):
+    def __init__(self, ids, request):
         self.ids = ids
+        self.request = request

--- a/press/raven.py
+++ b/press/raven.py
@@ -2,8 +2,16 @@ from pyramid import tweens
 import raven
 
 
+def _client_factory(registry):
+    return raven.Client(registry.settings.get('sentry.dsn'))
+
+
 def raven_tween_factory(handler, registry):
-    client = raven.Client(registry.settings.get('sentry.dsn'))
+    """A tween factory that registers a tween
+    that will capture uncaught exceptions.
+
+    """
+    client = _client_factory(registry)
 
     def tween(request):
         try:
@@ -18,10 +26,23 @@ def raven_tween_factory(handler, registry):
     return tween
 
 
+def _create_raven_client(request):
+    """Request attribute factory to give access non-critical exception
+    handling code a way to report issues.
+
+    """
+    return _client_factory(request.registry)
+
+
 def includeme(config):
     """Integrates Sentry's Raven client"""
     config.add_tween(
         'press.raven.raven_tween_factory',
         under=tweens.INGRESS,
         over=tweens.EXCVIEW,
+    )
+    config.add_request_method(
+        _create_raven_client,
+        name='raven_client',
+        reify=True,
     )

--- a/press/subscribers/__init__.py
+++ b/press/subscribers/__init__.py
@@ -1,0 +1,7 @@
+from press import events
+
+from .legacy_enqueue import legacy_enqueue as _legacy_enqueue
+
+
+def includeme(config):
+    config.add_subscriber(_legacy_enqueue, events.LegacyPublicationFinished)

--- a/press/subscribers/legacy_enqueue.py
+++ b/press/subscribers/legacy_enqueue.py
@@ -1,0 +1,34 @@
+import requests
+
+
+# subscriber for press.events.LegacyPublicationFinished
+def legacy_enqueue(event):
+    logger = event.request.log
+    # Build the enqueue RPC url
+    domain = event.request.domain
+    scheme = event.request.scheme
+    base_url = '{}://{}'.format(scheme, domain)
+    # The url is built specifically for collections, but works for modules,
+    # because the code for modules doesn't care about the extra options.
+    url_tmplt = (
+        '{base_url}/content/{module_id}/{version}'
+        '/enqueue?colcomplete=True&collxml=True'
+    )
+
+    timeout = (1, 5)  # (<connect>, <read>)
+    with requests.Session() as session:
+        for id, ver in event.ids:
+            version = '1.{}'.format(ver[0])
+            url = url_tmplt.format(
+                base_url=base_url,
+                module_id=id,
+                version=version,
+            )
+            try:
+                session.get(url, timeout=timeout)
+            except requests.exceptions.RequestException:
+                event.request.raven_client.captureException()
+                logger.exception("problem enqueuing '{}'".format(id))
+                continue
+            logger.info("enqueued '{}' within the legacy system"
+                        .format(id))

--- a/press/views/legacy_publishing.py
+++ b/press/views/legacy_publishing.py
@@ -57,12 +57,20 @@ def publish(request):
             for path, message in validation_msgs
         ]}
 
-    start_event = events.LegacyPublicationStarted(litezip_struct)
+    start_event = events.LegacyPublicationStarted(
+        litezip_struct,
+        request,
+    )
     request.registry.notify(start_event)
+
     with request.get_db_engine('common').begin() as db_conn:
         id_mapping = publish_litezip(litezip_struct, (publisher, message),
                                      db_conn)
-    finish_event = events.LegacyPublicationFinished(id_mapping.values())
+
+    finish_event = events.LegacyPublicationFinished(
+        id_mapping.values(),
+        request,
+    )
     request.registry.notify(finish_event)
 
     resp_data = []

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,4 +13,6 @@ python-dateutil==2.7.3
 
 recordclass==0.5
 
+requests-mock==1.5.0
+
 WebTest >= 1.3.1

--- a/tests/unit/subscribers/test_init.py
+++ b/tests/unit/subscribers/test_init.py
@@ -1,0 +1,23 @@
+import pretend
+
+from press import events
+from press import subscribers
+from press.subscribers import legacy_enqueue
+
+
+def test_includeme():
+    add_subscriber = pretend.call_recorder(lambda *a, **kw: None)
+    config = pretend.stub(
+        add_subscriber=add_subscriber,
+    )
+
+    # Call the target includeme
+    subscribers.includeme(config)
+
+    # Ensure the enqueuing publication finished subscriber is registered
+    assert add_subscriber.calls == [
+        pretend.call(
+            legacy_enqueue.legacy_enqueue,
+            events.LegacyPublicationFinished,
+        ),
+    ]

--- a/tests/unit/subscribers/test_legacy_enqueue.py
+++ b/tests/unit/subscribers/test_legacy_enqueue.py
@@ -1,0 +1,93 @@
+import pretend
+import requests
+import requests_mock as rmock
+
+from press.events import LegacyPublicationFinished
+
+from press.subscribers.legacy_enqueue import legacy_enqueue
+
+
+def test(requests_mock):
+    request_callback = pretend.call_recorder(
+        lambda request, context: 'enqueued')
+    # mock the request to enqueue
+    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
+
+    # stub out the logger
+    logger_info = pretend.call_recorder(lambda *a, **kw: None)
+    logger = pretend.stub(info=logger_info)
+    # Create an event with a stub request
+    ids = [
+        ('m12345', (2, None)),
+        ('m54321', (4, None)),
+        ('col32154', (5, 1)),
+    ]
+    request = pretend.stub(domain='example.org', scheme='mock', log=logger)
+    event = LegacyPublicationFinished(ids, request)
+
+    # Call the subcriber
+    legacy_enqueue(event)
+
+    # Check for request calls
+    assert len(request_callback.calls) == len(ids)
+    known_base_url = 'mock://example.org'
+    for i, (id, ver) in enumerate(ids):
+        url = (
+            '{}/content/{}/{}/enqueue?colcomplete=True&collxml=True'
+            .format(known_base_url, id, '1.{}'.format(ver[0]))
+        )
+        request, context = request_callback.calls[i].args
+        assert url == request.url
+
+    # Check for logging
+    assert len(logger_info.calls) == len(ids)
+    for i, (id, ver) in enumerate(ids):
+        assert id in logger_info.calls[i].args[0]
+
+
+def test_failed_request(requests_mock):
+    ids = [
+        ('m12345', (2, None)),
+        ('m54321', (4, None)),
+        ('col32154', (5, 1)),
+    ]
+
+    def request_callback(request, context):
+        if ids[0][0] in request.url:
+            raise requests.exceptions.ConnectTimeout
+        else:
+            return 'enqueued'
+
+    # mock a problem request to enqueue
+    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
+
+    # stub out the raven client
+    captureException = pretend.call_recorder(lambda: None)
+    raven_client = pretend.stub(captureException=captureException)
+    # stub out the logger
+    logger_info = pretend.call_recorder(lambda *a, **kw: None)
+    logger_exception = pretend.call_recorder(lambda *a, **kw: None)
+    logger = pretend.stub(
+        info=logger_info,
+        exception=logger_exception,
+    )
+    # Create an event with a stub request
+    request = pretend.stub(domain='example.org', scheme='mock',
+                           log=logger, raven_client=raven_client)
+    event = LegacyPublicationFinished(ids, request)
+
+    # Call the subcriber
+    legacy_enqueue(event)
+
+    # TODO have the other requests succeeded?
+
+    # Check raven was used...
+    assert captureException.calls
+
+    # Check for logging
+    assert logger_exception.calls == [
+        pretend.call("problem enqueuing '{}'".format(ids[0][0])),
+    ]
+    assert len(logger_info.calls) == len(ids) - 1
+    for i, (id, ver) in enumerate(ids[1:]):
+        assert id in logger_info.calls[i].args[0]

--- a/tests/unit/test_raven.py
+++ b/tests/unit/test_raven.py
@@ -2,7 +2,7 @@ import pretend
 import pytest
 from pyramid import tweens
 
-from press import raven
+from press import raven as press_raven
 
 
 class FauxException(Exception):
@@ -18,7 +18,7 @@ def test_tween_without_error(monkeypatch):
         context=pretend.stub(clear=context_clear),
     )
     client_factory = pretend.call_recorder(lambda dsn: client)
-    monkeypatch.setattr(raven.raven, 'Client', client_factory)
+    monkeypatch.setattr(press_raven.raven, 'Client', client_factory)
 
     # Stub out the calls to the registry
     test_dsn = '<dsn>'
@@ -28,7 +28,7 @@ def test_tween_without_error(monkeypatch):
     def handler(request):
         pass
 
-    tween = raven.raven_tween_factory(handler, registry)
+    tween = press_raven.raven_tween_factory(handler, registry)
 
     request = object()  # marker object
     tween(request)
@@ -48,7 +48,7 @@ def test_tween_with_error(monkeypatch):
         context=pretend.stub(clear=context_clear),
     )
     client_factory = pretend.call_recorder(lambda dsn: client)
-    monkeypatch.setattr(raven.raven, 'Client', client_factory)
+    monkeypatch.setattr(press_raven.raven, 'Client', client_factory)
 
     # Stub out the calls to the registry
     test_dsn = '<dsn>'
@@ -58,7 +58,7 @@ def test_tween_with_error(monkeypatch):
     def handler(request):
         raise FauxException
 
-    tween = raven.raven_tween_factory(handler, registry)
+    tween = press_raven.raven_tween_factory(handler, registry)
 
     request = object()  # marker object
     with pytest.raises(FauxException):
@@ -73,15 +73,29 @@ def test_tween_with_error(monkeypatch):
 def test_includeme():
     # FIXME Need to do under and over
     add_tween = pretend.call_recorder(lambda factory, over, under: None)
-    config = pretend.stub(add_tween=add_tween)
+    add_request_method = pretend.call_recorder(lambda fn, name, reify: None)
+    config = pretend.stub(
+        add_tween=add_tween,
+        add_request_method=add_request_method,
+    )
 
     # Call the target includeme
-    raven.includeme(config)
+    press_raven.includeme(config)
 
+    # Ensure the tween was registered
     assert config.add_tween.calls == [
         pretend.call(
             'press.raven.raven_tween_factory',
             under=tweens.INGRESS,
             over=tweens.EXCVIEW,
+        ),
+    ]
+
+    # Ensure the raven_client request attribute was registered
+    assert config.add_request_method.calls == [
+        pretend.call(
+            press_raven._create_raven_client,
+            name='raven_client',
+            reify=True,
         ),
     ]


### PR DESCRIPTION
- Add the raven client as a request method. This allows non-critical error
  handling to report issues without bubbling it up through the main process.

- Add publication finished event subscriber that contacts the legacy
  service to enqueue the content for export file builds (i.e. completezip,
  collxml, module export).

Addresses https://github.com/Connexions/nebuchadnezzar/issues/44

(The branch has a different name because this wasn't the original solution, but I forgot to change it)