### PR TITLE
Add a publication finished event subscriber that tracks publications

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -16,6 +16,10 @@ Change Log
   collxml, module export).
   See https://github.com/Connexions/nebuchadnezzar/issues/44
 
+- Add a publication finished event subscriber that tracks publications to
+  the filesystem. This is used primiarly as a safe guard incase we decide
+  or need to enable the "republishing" of books with shared pages.
+
 3.0.0
 -----
 

--- a/press/publishing.py
+++ b/press/publishing.py
@@ -8,8 +8,21 @@ from pyramid.threadlocal import get_current_registry
 __all__ = (
     'discover_content_dir',
     'expand_zip',
+    'get_var_location',
     'persist_file_to_filesystem',
 )
+
+
+def get_var_location(registry=None):
+    """Lookup the var location for this application.
+
+    :param registry: the application registry
+    :type registry: :class:`pyramid.registry.Registry`
+
+    """
+    if registry is None:
+        registry = get_current_registry()
+    return Path(registry.settings['shared_directory'])
 
 
 def persist_file_to_filesystem(file):
@@ -22,8 +35,8 @@ def persist_file_to_filesystem(file):
     :rtype: :class:`pathlib.Path`
 
     """
-    shared_directory = get_current_registry().settings['shared_directory']
-    _, filepath = tempfile.mkstemp(dir=shared_directory)
+    shared_directory = get_var_location()
+    _, filepath = tempfile.mkstemp(dir=str(shared_directory))
     filepath = Path(filepath)
     with filepath.open('wb') as fb:
         fb.write(file.read())
@@ -42,8 +55,7 @@ def expand_zip(file):
     :rtype: :class:`pathlib.Path`
 
     """
-    settings = get_current_registry().settings
-    shared_directory = Path(settings['shared_directory'])
+    shared_directory = get_var_location()
     _names = tempfile._get_candidate_names()
     while True:
         dir = shared_directory / next(_names)

--- a/press/subscribers/__init__.py
+++ b/press/subscribers/__init__.py
@@ -1,7 +1,25 @@
+from pyramid import events as pyramid_events
+
 from press import events
 
 from .legacy_enqueue import legacy_enqueue as _legacy_enqueue
+from .track_pubs import (
+    create_tracked_pubs_location,
+    track_publications_to_filesystem,
+)
 
 
 def includeme(config):
-    config.add_subscriber(_legacy_enqueue, events.LegacyPublicationFinished)
+    config.add_subscriber(
+        _legacy_enqueue,
+        events.LegacyPublicationFinished,
+    )
+    config.add_subscriber(
+        create_tracked_pubs_location,
+        pyramid_events.ApplicationCreated,
+    )
+    config.add_subscriber(
+        track_publications_to_filesystem,
+        events.LegacyPublicationFinished,
+
+    )

--- a/press/subscribers/track_pubs.py
+++ b/press/subscribers/track_pubs.py
@@ -1,0 +1,29 @@
+import json
+from datetime import datetime
+
+from press.publishing import get_var_location
+
+
+TRACKED_PUBS_DIR = 'tracked-pubs'
+
+
+def get_tracked_pubs_location(registry):
+    return get_var_location(registry) / TRACKED_PUBS_DIR
+
+
+# subscriber for pyramid.events.ApplicationCreated
+def create_tracked_pubs_location(event):
+    """Create the publication tracking directory"""
+    get_tracked_pubs_location(event.app.registry).mkdir(exist_ok=True)
+
+
+# subscriber for press.events.LegacyPublicationFinished
+def track_publications_to_filesystem(event):
+    """Track each publication as a file entry"""
+    # This is temporary (21-May-2018) to track what publications
+    # this application has made. The data may later be used
+    # if we decide or need to enable "republishing" of shared content.
+    directory = get_tracked_pubs_location(event.request.registry)
+    filename = '{}.json'.format(str(datetime.now()))
+    with (directory / filename).open('w') as fb:
+        json.dump(list(event.ids), fb)

--- a/tests/unit/subscribers/test_init.py
+++ b/tests/unit/subscribers/test_init.py
@@ -1,8 +1,9 @@
 import pretend
+from pyramid import events as pyramid_events
 
 from press import events
 from press import subscribers
-from press.subscribers import legacy_enqueue
+from press.subscribers import legacy_enqueue, track_pubs
 
 
 def test_includeme():
@@ -18,6 +19,14 @@ def test_includeme():
     assert add_subscriber.calls == [
         pretend.call(
             legacy_enqueue.legacy_enqueue,
+            events.LegacyPublicationFinished,
+        ),
+        pretend.call(
+            track_pubs.create_tracked_pubs_location,
+            pyramid_events.ApplicationCreated,
+        ),
+        pretend.call(
+            track_pubs.track_publications_to_filesystem,
             events.LegacyPublicationFinished,
         ),
     ]

--- a/tests/unit/subscribers/test_track_pubs.py
+++ b/tests/unit/subscribers/test_track_pubs.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+
+import pretend
+import pytest
+from pyramid.events import ApplicationCreated
+
+from press.events import LegacyPublicationFinished
+from press.subscribers.track_pubs import (
+    TRACKED_PUBS_DIR,
+    create_tracked_pubs_location,
+    get_tracked_pubs_location,
+    track_publications_to_filesystem,
+)
+
+
+def test_get_tracked_pubs_location(monkeypatch):
+    path = Path('/foo')
+    get_var_location = pretend.call_recorder(lambda registry: path)
+    monkeypatch.setattr(
+        'press.subscribers.track_pubs.get_var_location',
+        get_var_location,
+    )
+    registry = pretend.stub()
+
+    loc = get_tracked_pubs_location(registry)
+    assert loc == path / TRACKED_PUBS_DIR
+    assert get_var_location.calls == [
+        pretend.call(registry),
+    ]
+
+
+class TestCreateTrackedPubsLocation:
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmpdir):
+        self.shared_dir = Path(tmpdir.mkdir('shared'))
+        settings = {'shared_directory': self.shared_dir}
+        registry = pretend.stub(settings=settings)
+        self.app = pretend.stub(registry=registry)
+
+    def test(self):
+        event = ApplicationCreated(self.app)
+        create_tracked_pubs_location(event)
+
+        expected_location = self.shared_dir / TRACKED_PUBS_DIR
+        assert expected_location.exists()
+
+    def test_exists(self):
+        # Create the directory
+        expected_location = self.shared_dir / TRACKED_PUBS_DIR
+        expected_location.mkdir()
+
+        # test this doesn't error...
+        event = ApplicationCreated(self.app)
+        create_tracked_pubs_location(event)
+        assert expected_location.exists()
+
+
+def test_track_publications_to_filesystem(tmpdir, monkeypatch):
+    shared_dir = Path(tmpdir.mkdir('shared'))
+    # Note this directory is created at application startup
+    (shared_dir / TRACKED_PUBS_DIR).mkdir()
+    settings = {'shared_directory': shared_dir}
+    registry = pretend.stub(settings=settings)
+
+    # Create an event with a stub request
+    ids = [
+        ('m12345', (2, None)),
+        ('m54321', (4, None)),
+        ('col32154', (5, 1)),
+    ]
+    request = pretend.stub(registry=registry)
+    event = LegacyPublicationFinished(ids, request)
+
+    # stub the datetime.now()
+    datetime = pretend.stub(now=lambda: 'now')
+    monkeypatch.setattr(
+        'press.subscribers.track_pubs.datetime',
+        datetime,
+    )
+
+    # Call the subcriber
+    track_publications_to_filesystem(event)
+
+    # Check for a file
+    with (shared_dir / TRACKED_PUBS_DIR / 'now.json').open('r') as fb:
+        # ... because json converts tuples to lists
+        json_formatted_ids = [[x[0], list(x[1])] for x in ids]
+        assert json.load(fb) == json_formatted_ids


### PR DESCRIPTION
Add a publication finished event subscriber that tracks publications to
the filesystem. This is used primarily as a safe guard incase we decide
or need to enable the "republishing" of books with shared pages.