### PR TITLE
Add a publication finished event subscriber that purges the cache

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,12 @@
 Change Log
 ==========
 
+3.2.0
+-----
+
+- Add a publication finished event subscriber that purges the cache
+  for legacy urls that contain the 'latest' version classifier.
+
 3.1.0
 -----
 

--- a/press/subscribers/__init__.py
+++ b/press/subscribers/__init__.py
@@ -3,6 +3,7 @@ from pyramid import events as pyramid_events
 from press import events
 
 from .legacy_enqueue import legacy_enqueue as _legacy_enqueue
+from .purge_cache import purge_cache as _purge_cache
 from .track_pubs import (
     create_tracked_pubs_location,
     track_publications_to_filesystem,
@@ -21,5 +22,8 @@ def includeme(config):
     config.add_subscriber(
         track_publications_to_filesystem,
         events.LegacyPublicationFinished,
-
+    )
+    config.add_subscriber(
+        _purge_cache,
+        events.LegacyPublicationFinished,
     )

--- a/press/subscribers/legacy_enqueue.py
+++ b/press/subscribers/legacy_enqueue.py
@@ -4,6 +4,7 @@ import requests
 # subscriber for press.events.LegacyPublicationFinished
 def legacy_enqueue(event):
     logger = event.request.log
+
     # Build the enqueue RPC url
     domain = event.request.domain
     scheme = event.request.scheme

--- a/press/subscribers/purge_cache.py
+++ b/press/subscribers/purge_cache.py
@@ -1,0 +1,37 @@
+import requests
+
+
+def _build_legacy_domain(domain):
+    """Given the existing domain, translate it to the legacy domain."""
+    sep = len(domain.split('.')) > 2 and '-' or '.'
+    return 'legacy{}{}'.format(sep, domain)
+
+
+# subscriber for press.events.LegacyPublicationFinished
+def purge_cache(event):
+    logger = event.request.log
+    just_ids = list(map(lambda x: x[0], event.ids))
+
+    # Build the legacy domain from the current request domain.
+    domain = _build_legacy_domain(event.request.domain)
+
+    # Build the purge url
+    scheme = event.request.scheme
+    base_url = '{}://{}'.format(scheme, domain)
+    regex_ids = '({})'.format('|'.join(just_ids))
+    url = '{}/content/{}/latest.*$'.format(base_url, regex_ids)
+
+    purge_req = requests.Request('PURGE_REGEXP', url)
+    purge_req = purge_req.prepare()
+    timeout = (1, 5)  # (<connect>, <read>)
+    with requests.Session() as session:
+        try:
+            session.send(purge_req, timeout=timeout)
+        except requests.exceptions.RequestException:
+            event.request.raven_client.captureException()
+            logger.exception("problem purging with {}".format(url))
+        else:
+            logger.debug("purge url:  {}".format(url))
+            logger.info("purged urls for the 'latest' version of '{}' "
+                        "on the legacy domain"
+                        .format(', '.join(just_ids)))

--- a/press/subscribers/purge_cache.py
+++ b/press/subscribers/purge_cache.py
@@ -1,10 +1,31 @@
 import requests
 
 
+# Range of the sequence of ids to put into a purge url
+ID_CHUNK_SIZE = 10
+# Used by the quest
+TIMEOUT = (1, 5)  # (<connect>, <read>)
+
+
 def _build_legacy_domain(domain):
     """Given the existing domain, translate it to the legacy domain."""
     sep = len(domain.split('.')) > 2 and '-' or '.'
     return 'legacy{}{}'.format(sep, domain)
+
+
+def _gen_purge_url(base, ids):
+    """Given the base url (scheme and domain) and a sequence of ids
+    (e.g. col11629, m45111), generate a purge url.
+
+    """
+    regex_ids = '({})'.format('|'.join(ids))
+    return '{}/content/{}/latest.*$'.format(base, regex_ids)
+
+
+def _make_request(url):
+    """requests.Request factory for creating a purge request"""
+    purge_req = requests.Request('PURGE_REGEXP', url)
+    return purge_req.prepare()
 
 
 # subscriber for press.events.LegacyPublicationFinished
@@ -14,24 +35,25 @@ def purge_cache(event):
 
     # Build the legacy domain from the current request domain.
     domain = _build_legacy_domain(event.request.domain)
-
-    # Build the purge url
+    # Build the base part of the purge url
     scheme = event.request.scheme
     base_url = '{}://{}'.format(scheme, domain)
-    regex_ids = '({})'.format('|'.join(just_ids))
-    url = '{}/content/{}/latest.*$'.format(base_url, regex_ids)
 
-    purge_req = requests.Request('PURGE_REGEXP', url)
-    purge_req = purge_req.prepare()
-    timeout = (1, 5)  # (<connect>, <read>)
     with requests.Session() as session:
-        try:
-            session.send(purge_req, timeout=timeout)
-        except requests.exceptions.RequestException:
-            event.request.raven_client.captureException()
-            logger.exception("problem purging with {}".format(url))
-        else:
-            logger.debug("purge url:  {}".format(url))
-            logger.info("purged urls for the 'latest' version of '{}' "
-                        "on the legacy domain"
-                        .format(', '.join(just_ids)))
+        start = 0
+        range_stop = len(just_ids) + ID_CHUNK_SIZE
+        for end in range(ID_CHUNK_SIZE, range_stop, ID_CHUNK_SIZE):
+            url = _gen_purge_url(base_url, just_ids[start:end])
+            req = _make_request(url)
+            try:
+                session.send(req, timeout=TIMEOUT)
+            except requests.exceptions.RequestException:
+                event.request.raven_client.captureException()
+                logger.exception("problem purging with {}".format(url))
+            else:
+                logger.debug("purge url:  {}".format(url))
+                logger.info("purged urls for the 'latest' version of '{}' "
+                            "on the legacy domain"
+                            .format(', '.join(just_ids)))
+            finally:
+                start = end

--- a/tests/unit/subscribers/test_init.py
+++ b/tests/unit/subscribers/test_init.py
@@ -3,7 +3,11 @@ from pyramid import events as pyramid_events
 
 from press import events
 from press import subscribers
-from press.subscribers import legacy_enqueue, track_pubs
+from press.subscribers import (
+    legacy_enqueue,
+    purge_cache,
+    track_pubs,
+)
 
 
 def test_includeme():
@@ -27,6 +31,10 @@ def test_includeme():
         ),
         pretend.call(
             track_pubs.track_publications_to_filesystem,
+            events.LegacyPublicationFinished,
+        ),
+        pretend.call(
+            purge_cache.purge_cache,
             events.LegacyPublicationFinished,
         ),
     ]

--- a/tests/unit/subscribers/test_purge_cache.py
+++ b/tests/unit/subscribers/test_purge_cache.py
@@ -1,0 +1,126 @@
+import pretend
+import requests
+import requests_mock as rmock
+
+from press.events import LegacyPublicationFinished
+
+from press.subscribers.purge_cache import (
+    _build_legacy_domain,
+    purge_cache,
+)
+
+
+class TestBuildLegacyDomain:
+
+    def test_prod_domain(self):
+        domain = 'example.com'
+        assert _build_legacy_domain(domain) == '.'.join(['legacy', domain])
+
+    def test_dev_domain(self):
+        domain = 'dev.example.com'
+        assert _build_legacy_domain(domain) == '-'.join(['legacy', domain])
+
+
+class TestPurgeCache:
+
+    def test(self, requests_mock):
+        request_callback = pretend.call_recorder(
+            lambda request, context: 'purged')
+        # mock the request to purge
+        requests_mock.register_uri(
+            'PURGE_REGEXP',
+            rmock.ANY,
+            text=request_callback,
+        )
+
+        # stub out the logger
+        logger_info = pretend.call_recorder(lambda *a, **kw: None)
+        logger_debug = pretend.call_recorder(lambda *a, **kw: None)
+        logger = pretend.stub(info=logger_info, debug=logger_debug)
+        # Create an event with a stub request
+        ids = [
+            ('m12345', (2, None)),
+            ('m54321', (4, None)),
+            ('col32154', (5, 1)),
+        ]
+        request = pretend.stub(
+            domain='example.org',
+            scheme='mock',
+            log=logger,
+        )
+        event = LegacyPublicationFinished(ids, request)
+
+        # Call the subcriber
+        purge_cache(event)
+
+        # Check for request call
+        assert request_callback.calls
+        known_base_url = 'mock://legacy.example.org'
+        url = (
+            '{}/content/({})/latest.*$'
+            .format(known_base_url, '|'.join([x[0] for x in ids]))
+        )
+        sent_request, context = request_callback.calls[0].args
+        assert url == sent_request.url
+
+        # Check for logging
+        assert logger_debug.calls == [
+            pretend.call("purge url:  {}".format(url)),
+        ]
+        assert logger_info.calls == [
+            pretend.call("purged urls for the 'latest' version of '{}' "
+                         "on the legacy domain"
+                         .format(', '.join(map(lambda x: x[0], ids)))),
+        ]
+
+    def test_failed_request(self, requests_mock):
+        # mock the failing request to purge
+        requests_mock.register_uri(
+            'PURGE_REGEXP',
+            rmock.ANY,
+            exc=requests.exceptions.ConnectTimeout,
+        )
+
+        # stub out the raven client
+        captureException = pretend.call_recorder(lambda: None)
+        raven_client = pretend.stub(captureException=captureException)
+        # stub out the logger
+        logger_info = pretend.call_recorder(lambda *a, **kw: None)
+        logger_debug = pretend.call_recorder(lambda *a, **kw: None)
+        logger_exception = pretend.call_recorder(lambda *a, **kw: None)
+        logger = pretend.stub(
+            info=logger_info,
+            debug=logger_debug,
+            exception=logger_exception,
+        )
+        # Create an event with a stub request
+        ids = [
+            ('m12345', (2, None)),
+            ('m54321', (4, None)),
+            ('col32154', (5, 1)),
+        ]
+        request = pretend.stub(
+            domain='example.org',
+            scheme='mock',
+            log=logger,
+            raven_client=raven_client,
+        )
+        event = LegacyPublicationFinished(ids, request)
+
+        # Call the subcriber
+        purge_cache(event)
+
+        # Check raven was used...
+        assert captureException.calls
+
+        known_base_url = 'mock://legacy.example.org'
+        url = (
+            '{}/content/({})/latest.*$'
+            .format(known_base_url, '|'.join([x[0] for x in ids]))
+        )
+        # Check for logging
+        assert logger_debug.calls == []
+        assert logger_info.calls == []
+        assert logger_exception.calls == [
+            pretend.call('problem purging with {}'.format(url)),
+        ]

--- a/tests/unit/subscribers/test_purge_cache.py
+++ b/tests/unit/subscribers/test_purge_cache.py
@@ -5,6 +5,7 @@ import requests_mock as rmock
 from press.events import LegacyPublicationFinished
 
 from press.subscribers.purge_cache import (
+    ID_CHUNK_SIZE,
     _build_legacy_domain,
     purge_cache,
 )
@@ -124,3 +125,100 @@ class TestPurgeCache:
         assert logger_exception.calls == [
             pretend.call('problem purging with {}'.format(url)),
         ]
+
+    def test_large_publication(self, requests_mock):
+
+        def _make_callback(text='purged', is_exception=False):
+            def callback(request, context):
+                if is_exception:
+                    raise requests.exceptions.ConnectTimeout
+                else:
+                    return text
+            return callback
+
+        # mock the failing request to purge
+        response_list = [
+            _make_callback(),
+            _make_callback(is_exception=True),
+            _make_callback(),
+        ]
+        # format the responses for registration and call recording
+        response_list = [
+            {'text': pretend.call_recorder(y)} for y in response_list
+        ]
+        # register the mock request to purge
+        requests_mock.register_uri(
+            'PURGE_REGEXP',
+            rmock.ANY,
+            response_list,
+        )
+
+        # stub out the raven client
+        captureException = pretend.call_recorder(lambda: None)
+        raven_client = pretend.stub(captureException=captureException)
+        # stub out the logger
+        logger_info = pretend.call_recorder(lambda *a, **kw: None)
+        logger_debug = pretend.call_recorder(lambda *a, **kw: None)
+        logger_exception = pretend.call_recorder(lambda *a, **kw: None)
+        logger = pretend.stub(
+            info=logger_info,
+            debug=logger_debug,
+            exception=logger_exception,
+        )
+        # Create an event with a stub request
+        ids = [
+            ('m12', (2, None)),
+            ('m54', (4, None)),
+            ('m22', (2, None)),
+            ('m64', (4, None)),
+            ('m32', (2, None)),
+            ('m74', (4, None)),
+            ('m42', (2, None)),
+            ('m84', (4, None)),
+            ('m52', (2, None)),
+            ('m94', (4, None)),
+            ('m62', (2, None)),
+            ('m14', (4, None)),
+            ('m72', (2, None)),
+            ('m24', (4, None)),
+            ('m82', (2, None)),
+            ('m34', (4, None)),
+            ('m92', (2, None)),
+            ('m44', (4, None)),
+            ('col32', (5, 1)),
+            ('col42', (5, 1)),
+            ('col52', (5, 1)),
+            ('col21', (5, 1)),
+            ('col52', (5, 1)),
+        ]
+        request = pretend.stub(
+            domain='example.org',
+            scheme='mock',
+            log=logger,
+            raven_client=raven_client,
+        )
+        event = LegacyPublicationFinished(ids, request)
+
+        # Call the subcriber
+        purge_cache(event)
+
+        # Check raven was used...
+        assert len(captureException.calls) == 1
+
+        # Check for logging, but not the details, because that's not the
+        # focus of this particular test.
+        assert len(logger_debug.calls) == 2
+        assert len(logger_info.calls) == 2
+        assert len(logger_exception.calls) == 1
+
+        # Check the requests have the correct set of ids in them.
+        just_ids = list(map(lambda x: x[0], ids))
+        sent_requests = map(
+            lambda x: x['text'].calls[0].args[0],
+            response_list,
+        )
+        for i, request in enumerate(sent_requests):
+            start = i * ID_CHUNK_SIZE
+            end = (i + 1) * ID_CHUNK_SIZE
+            expected_text = '|'.join(just_ids[start:end])
+            assert expected_text in request.url


### PR DESCRIPTION
Add a publication finished event subscriber that purges the cache
for legacy urls that contain the 'latest' version classifier.

Here is example purge url sent by this event subscriber: `https://legacy-qa.cnx.org/content/(col11407|m45231)/latest.*$`