### PR TITLE
Fix internal usage of the version as a tuple of major and minor

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,12 @@
 Change Log
 ==========
 
+3.2.1
+-----
+
+- Fix internal usage of the version by consistently using a version
+  tuple (major and minor) between functions rather than the legacy version.
+
 3.2.0
 -----
 

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -69,9 +69,11 @@ def publish_legacy_book(model, metadata, submission, db_conn):
     ).returning(
         t.modules.c.module_ident,
         t.modules.c.moduleid,
-        t.modules.c.version,
+        t.modules.c.major_version,
+        t.modules.c.minor_version,
     ))
-    ident, id, version = result.fetchone()
+    ident, id, major_version, minor_version = result.fetchone()
+    version = (major_version, minor_version,)
 
     # Insert subjects metadata
     stmt = (text('INSERT INTO moduletags '

--- a/press/legacy_publishing/litezip.py
+++ b/press/legacy_publishing/litezip.py
@@ -7,6 +7,7 @@ from press.parsers import parse_collection_metadata, parse_module_metadata
 
 from .collection import publish_legacy_book
 from .module import publish_legacy_page
+from ..utils import convert_version_to_legacy_version
 
 
 __all__ = (
@@ -51,7 +52,8 @@ def publish_litezip(struct, submission, db_conn):
             version_attrib_name = (
                 '{{{}}}version-at-this-collection-version'
                 .format(COLLECTION_NSMAP['cnxorg']))
-            elm.attrib[version_attrib_name] = version
+            legacy_version = convert_version_to_legacy_version(version)
+            elm.attrib[version_attrib_name] = legacy_version
 
     # Rebuild the Collection tree from the newly published Modules.
     with collection.file.open('wb') as fb:

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -67,9 +67,11 @@ def publish_legacy_page(model, metadata, submission, db_conn):
     ).returning(
         t.modules.c.module_ident,
         t.modules.c.moduleid,
-        t.modules.c.version,
+        t.modules.c.major_version,
+        t.modules.c.minor_version,
     ))
-    ident, id, version = result.fetchone()
+    ident, id, major_version, minor_version = result.fetchone()
+    version = (major_version, minor_version,)
 
     # Insert subjects metadata
     stmt = (text('INSERT INTO moduletags '

--- a/press/legacy_publishing/utils.py
+++ b/press/legacy_publishing/utils.py
@@ -1,6 +1,8 @@
 from litezip.main import COLLECTION_NSMAP
 from lxml import etree
 
+from ..utils import convert_version_to_legacy_version
+
 
 __all__ = (
     'replace_id_and_version',
@@ -14,8 +16,8 @@ def replace_id_and_version(model, id, version):
     :type model: :class:`litezip.Collection` or :class:`litezip.Module`
     :param id: id
     :type id: str
-    :param version: version
-    :type version: str
+    :param version: major and minor version tuple
+    :type version: tuple of int
 
     """
     # Rewrite the content with the id and version
@@ -24,6 +26,6 @@ def replace_id_and_version(model, id, version):
     elm = xml.xpath('//md:content-id', namespaces=COLLECTION_NSMAP)[0]
     elm.text = id
     elm = xml.xpath('//md:version', namespaces=COLLECTION_NSMAP)[0]
-    elm.text = version
+    elm.text = convert_version_to_legacy_version(version)
     with model.file.open('wb') as fb:
         fb.write(etree.tostring(xml))

--- a/press/utils.py
+++ b/press/utils.py
@@ -1,0 +1,13 @@
+__all__ = (
+    'convert_version_to_legacy_version',
+)
+
+
+def convert_version_to_legacy_version(version):
+    """Converts a version to a legacy version.
+
+    :param version: content's major and minor version
+    :type version: tuple of int
+
+    """
+    return '1.{}'.format(version[0])

--- a/press/views/legacy_publishing.py
+++ b/press/views/legacy_publishing.py
@@ -11,6 +11,7 @@ from ..publishing import (
     expand_zip,
     persist_file_to_filesystem,
 )
+from ..utils import convert_version_to_legacy_version
 
 
 @view_config(route_name='api.v3.publications', request_method=['POST'],
@@ -75,11 +76,12 @@ def publish(request):
 
     resp_data = []
     for src_id, (id, ver) in id_mapping.items():
+        legacy_version = convert_version_to_legacy_version(ver)
         resp_data.append({
             'source_id': src_id,
             'id': id,
-            'version': ver,
+            'version': legacy_version,
             'url': request.route_url('api.v1.versioned_content',
-                                     id=id, ver=ver),
+                                     id=id, ver=legacy_version),
         })
     return resp_data

--- a/tests/functional/legacy_publishing/test_litezip.py
+++ b/tests/functional/legacy_publishing/test_litezip.py
@@ -37,8 +37,8 @@ def test_publish_litezip(
         )
 
     expected_id_map = {
-        new_module.id: (new_module.id, '1.2'),
-        collection.id: (collection.id, '1.2'),
+        new_module.id: (new_module.id, (2, None)),
+        collection.id: (collection.id, (2, 1)),
     }
     assert id_map == expected_id_map
 

--- a/tests/unit/legacy_publishing/test_utils.py
+++ b/tests/unit/legacy_publishing/test_utils.py
@@ -6,7 +6,7 @@ from press.legacy_publishing.utils import (
 def test_replace_id_and_version(content_util):
     module = content_util.gen_module()
     id = '$$$_id_$$$'
-    version = '$$$_version_$$$'
+    version = ('$', '%',)
 
     # Call the target
     replace_id_and_version(module, id, version)
@@ -15,4 +15,4 @@ def test_replace_id_and_version(content_util):
     with module.file.open('r') as fb:
         text = fb.read()
     assert id in text
-    assert version in text
+    assert '1.{}'.format(version[0]) in text

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,13 @@
+from press.utils import convert_version_to_legacy_version
+
+
+def test_module_version():
+    version = (4, None)  # Note, modules do not have a minor version
+    expected_version = '1.{}'.format(version[0])
+    assert convert_version_to_legacy_version(version) == expected_version
+
+
+def test_collection_version():
+    version = (8, 11)
+    expected_version = '1.{}'.format(version[0])
+    assert convert_version_to_legacy_version(version) == expected_version


### PR DESCRIPTION
Fix internal usage of the version by consistently using a version tuple (major and minor) between functions rather than the legacy version.