### PR TITLE
Address legacy enqueuing read timeouts by sorting the content ids

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,15 @@
 Change Log
 ==========
 
+3.2.2
+-----
+
+- Address legacy enqueuing read timeouts by sorting the content so that
+  the collection is sent first. All other requests can timeout
+  without concern. This only addresses the problem and does not fully
+  resolve it.
+  See https://github.com/Connexions/cnx-press/issues/100
+
 3.2.1
 -----
 

--- a/press/subscribers/legacy_enqueue.py
+++ b/press/subscribers/legacy_enqueue.py
@@ -17,8 +17,9 @@ def legacy_enqueue(event):
     )
 
     timeout = (1, 5)  # (<connect>, <read>)
+    ids = sorted(event.ids)
     with requests.Session() as session:
-        for id, ver in event.ids:
+        for id, ver in ids:
             version = '1.{}'.format(ver[0])
             url = url_tmplt.format(
                 base_url=base_url,

--- a/tests/unit/subscribers/test_legacy_enqueue.py
+++ b/tests/unit/subscribers/test_legacy_enqueue.py
@@ -31,7 +31,7 @@ def test(requests_mock):
     # Check for request calls
     assert len(request_callback.calls) == len(ids)
     known_base_url = 'mock://example.org'
-    for i, (id, ver) in enumerate(ids):
+    for i, (id, ver) in enumerate(sorted(ids)):
         url = (
             '{}/content/{}/{}/enqueue?colcomplete=True&collxml=True'
             .format(known_base_url, id, '1.{}'.format(ver[0]))
@@ -41,7 +41,7 @@ def test(requests_mock):
 
     # Check for logging
     assert len(logger_info.calls) == len(ids)
-    for i, (id, ver) in enumerate(ids):
+    for i, (id, ver) in enumerate(sorted(ids)):
         assert id in logger_info.calls[i].args[0]
 
 
@@ -53,7 +53,7 @@ def test_failed_request(requests_mock):
     ]
 
     def request_callback(request, context):
-        if ids[0][0] in request.url:
+        if ids[1][0] in request.url:
             raise requests.exceptions.ConnectTimeout
         else:
             return 'enqueued'
@@ -86,8 +86,8 @@ def test_failed_request(requests_mock):
 
     # Check for logging
     assert logger_exception.calls == [
-        pretend.call("problem enqueuing '{}'".format(ids[0][0])),
+        pretend.call("problem enqueuing '{}'".format(ids[1][0])),
     ]
     assert len(logger_info.calls) == len(ids) - 1
-    for i, (id, ver) in enumerate(ids[1:]):
+    for i, (id, ver) in enumerate(sorted(ids)[:-1]):
         assert id in logger_info.calls[i].args[0]


### PR DESCRIPTION
Address legacy enqueuing read timeouts by sorting the content so that
the collection is sent first. All other requests can timeout
without concern. This only addresses the problem and does not fully
resolve it.

Addresses #100 