### PR TITLE
Fix error log entry in the cache purging subscriber

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,12 @@
 Change Log
 ==========
 
+3.2.4
+-----
+
+- Fix error log entry in the cache purging subscriber
+  to only output the content ids within the context of the loop cycle.
+
 3.2.3
 -----
 

--- a/press/subscribers/purge_cache.py
+++ b/press/subscribers/purge_cache.py
@@ -43,7 +43,8 @@ def purge_cache(event):
         start = 0
         range_stop = len(just_ids) + ID_CHUNK_SIZE
         for end in range(ID_CHUNK_SIZE, range_stop, ID_CHUNK_SIZE):
-            url = _gen_purge_url(base_url, just_ids[start:end])
+            ids = just_ids[start:end]
+            url = _gen_purge_url(base_url, ids)
             req = _make_request(url)
             try:
                 session.send(req, timeout=TIMEOUT)
@@ -54,6 +55,6 @@ def purge_cache(event):
                 logger.debug("purge url:  {}".format(url))
                 logger.info("purged urls for the 'latest' version of '{}' "
                             "on the legacy domain"
-                            .format(', '.join(just_ids)))
+                            .format(', '.join(ids)))
             finally:
                 start = end


### PR DESCRIPTION
This fix produces a message that is just about the ids for the error log line,
rather than printing all the ids to be purged.