### PR TITLE
Add subscriber to trigger update of legacy latest 

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,14 @@
 Change Log
 ==========
 
+3.3.0
+-----
+
+- Adds an publication finished event subscriber to request the 'latest'
+  version of the content from the legacy software to have it read
+  the latest version from the database, thus allowing it to have an
+  updated object representation of the data for use with other requests.
+
 3.2.4
 -----
 

--- a/press/subscribers/__init__.py
+++ b/press/subscribers/__init__.py
@@ -3,6 +3,7 @@ from pyramid import events as pyramid_events
 from press import events
 
 from .legacy_enqueue import legacy_enqueue as _legacy_enqueue
+from .legacy_update_latest import legacy_update_latest as _legacy_update_latest
 from .purge_cache import purge_cache as _purge_cache
 from .track_pubs import (
     create_tracked_pubs_location,
@@ -11,6 +12,10 @@ from .track_pubs import (
 
 
 def includeme(config):
+    config.add_subscriber(
+        _legacy_update_latest,
+        events.LegacyPublicationFinished,
+    )
     config.add_subscriber(
         _legacy_enqueue,
         events.LegacyPublicationFinished,

--- a/press/subscribers/legacy_enqueue.py
+++ b/press/subscribers/legacy_enqueue.py
@@ -1,12 +1,14 @@
 import requests
 
+from press.utils import convert_to_legacy_domain
+
 
 # subscriber for press.events.LegacyPublicationFinished
 def legacy_enqueue(event):
     logger = event.request.log
 
     # Build the enqueue RPC url
-    domain = event.request.domain
+    domain = convert_to_legacy_domain(event.request.domain)
     scheme = event.request.scheme
     base_url = '{}://{}'.format(scheme, domain)
     # The url is built specifically for collections, but works for modules,

--- a/press/subscribers/legacy_update_latest.py
+++ b/press/subscribers/legacy_update_latest.py
@@ -1,0 +1,38 @@
+import requests
+
+from press.utils import convert_to_legacy_domain
+
+
+# subscriber for press.events.LegacyPublicationFinished
+def legacy_update_latest(event):
+    logger = event.request.log
+
+    # Build the legacy domain from the current request domain.
+    domain = convert_to_legacy_domain(event.request.domain)
+    # Build the latest content url
+    scheme = event.request.scheme
+    base_url = '{}://{}'.format(scheme, domain)
+    url_tmplt = ('{base_url}/content/{module_id}/latest')
+
+    timeout = (1, 120)  # (<connect>, <read>)
+    ids = sorted(event.ids)
+    with requests.Session() as session:
+        for id, _ in ids:
+            url = url_tmplt.format(
+                base_url=base_url,
+                module_id=id,
+            )
+            try:
+                session.get(url, timeout=timeout)
+            except requests.exceptions.RequestException:
+                event.request.raven_client.captureException()
+                # try one more time
+                try:
+                    session.get(url, timeout=timeout)
+                except requests.exceptions.RequestException:
+                    event.request.raven_client.captureException()
+                    logger.exception("problem fetching '{}'".format(id))
+                    continue
+                continue
+            logger.info("fetched '{}/latest' within the legacy system"
+                        .format(id))

--- a/press/subscribers/purge_cache.py
+++ b/press/subscribers/purge_cache.py
@@ -1,16 +1,12 @@
 import requests
 
+from press.utils import convert_to_legacy_domain
+
 
 # Range of the sequence of ids to put into a purge url
 ID_CHUNK_SIZE = 10
 # Used by the quest
 TIMEOUT = (1, 5)  # (<connect>, <read>)
-
-
-def _build_legacy_domain(domain):
-    """Given the existing domain, translate it to the legacy domain."""
-    sep = len(domain.split('.')) > 2 and '-' or '.'
-    return 'legacy{}{}'.format(sep, domain)
 
 
 def _gen_purge_url(base, ids):
@@ -34,7 +30,7 @@ def purge_cache(event):
     just_ids = list(map(lambda x: x[0], event.ids))
 
     # Build the legacy domain from the current request domain.
-    domain = _build_legacy_domain(event.request.domain)
+    domain = convert_to_legacy_domain(event.request.domain)
     # Build the base part of the purge url
     scheme = event.request.scheme
     base_url = '{}://{}'.format(scheme, domain)

--- a/press/utils.py
+++ b/press/utils.py
@@ -1,4 +1,5 @@
 __all__ = (
+    'convert_to_legacy_domain',
     'convert_version_to_legacy_version',
 )
 
@@ -11,3 +12,9 @@ def convert_version_to_legacy_version(version):
 
     """
     return '1.{}'.format(version[0])
+
+
+def convert_to_legacy_domain(domain):
+    """Given the existing domain, convert it to the legacy domain."""
+    sep = len(domain.split('.')) > 2 and '-' or '.'
+    return 'legacy{}{}'.format(sep, domain)

--- a/tests/unit/subscribers/test_init.py
+++ b/tests/unit/subscribers/test_init.py
@@ -5,6 +5,7 @@ from press import events
 from press import subscribers
 from press.subscribers import (
     legacy_enqueue,
+    legacy_update_latest,
     purge_cache,
     track_pubs,
 )
@@ -21,6 +22,10 @@ def test_includeme():
 
     # Ensure the enqueuing publication finished subscriber is registered
     assert add_subscriber.calls == [
+        pretend.call(
+            legacy_update_latest.legacy_update_latest,
+            events.LegacyPublicationFinished,
+        ),
         pretend.call(
             legacy_enqueue.legacy_enqueue,
             events.LegacyPublicationFinished,

--- a/tests/unit/subscribers/test_legacy_enqueue.py
+++ b/tests/unit/subscribers/test_legacy_enqueue.py
@@ -3,8 +3,11 @@ import requests
 import requests_mock as rmock
 
 from press.events import LegacyPublicationFinished
-
 from press.subscribers.legacy_enqueue import legacy_enqueue
+
+from tests.helpers import (
+    retryable_timeout_request_mock_callback
+)
 
 
 def test(requests_mock):
@@ -45,7 +48,7 @@ def test(requests_mock):
         assert id in logger_info.calls[i].args[0]
 
 
-def test_failed_request(requests_mock):
+def test_failed_request_and_retry_failed(requests_mock):
     ids = [
         ('m12345', (2, None)),
         ('m54321', (4, None)),
@@ -79,8 +82,6 @@ def test_failed_request(requests_mock):
     # Call the subcriber
     legacy_enqueue(event)
 
-    # TODO have the other requests succeeded?
-
     # Check raven was used...
     assert captureException.calls
 
@@ -91,3 +92,45 @@ def test_failed_request(requests_mock):
     assert len(logger_info.calls) == len(ids) - 1
     for i, (id, ver) in enumerate(sorted(ids)[:-1]):
         assert id in logger_info.calls[i].args[0]
+
+
+def test_failed_request_and_retry_success(requests_mock):
+    ids = [
+        ('m12345', (2, None)),
+        ('m54321', (4, None)),
+        ('col32154', (5, 1)),
+    ]
+
+    @retryable_timeout_request_mock_callback
+    def request_callback(request, context, tries):
+        # fails at first but succeeds on the second try
+        if ids[1][0] in request.url and tries < 2:
+            raise requests.exceptions.ConnectTimeout
+        return 'enqueued'
+
+    # mock a problem request to enqueue
+    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
+
+    # stub out the raven client
+    captureException = pretend.call_recorder(lambda: None)
+    raven_client = pretend.stub(captureException=captureException)
+    # stub out the logger
+    logger_info = pretend.call_recorder(lambda *a, **kw: None)
+    logger_exception = pretend.call_recorder(lambda *a, **kw: None)
+    logger = pretend.stub(
+        info=logger_info,
+        exception=logger_exception,
+    )
+    # Create an event with a stub request
+    request = pretend.stub(domain='example.org', scheme='mock',
+                           log=logger, raven_client=raven_client)
+    event = LegacyPublicationFinished(ids, request)
+
+    # Call the subcriber
+    legacy_enqueue(event)
+
+    # Check raven was used...
+    assert captureException.calls
+
+    # Check for logging
+    assert logger_exception.calls == []

--- a/tests/unit/subscribers/test_purge_cache.py
+++ b/tests/unit/subscribers/test_purge_cache.py
@@ -6,20 +6,8 @@ from press.events import LegacyPublicationFinished
 
 from press.subscribers.purge_cache import (
     ID_CHUNK_SIZE,
-    _build_legacy_domain,
     purge_cache,
 )
-
-
-class TestBuildLegacyDomain:
-
-    def test_prod_domain(self):
-        domain = 'example.com'
-        assert _build_legacy_domain(domain) == '.'.join(['legacy', domain])
-
-    def test_dev_domain(self):
-        domain = 'dev.example.com'
-        assert _build_legacy_domain(domain) == '-'.join(['legacy', domain])
 
 
 class TestPurgeCache:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,7 @@
-from press.utils import convert_version_to_legacy_version
+from press.utils import (
+    convert_to_legacy_domain,
+    convert_version_to_legacy_version,
+)
 
 
 def test_module_version():
@@ -11,3 +14,16 @@ def test_collection_version():
     version = (8, 11)
     expected_version = '1.{}'.format(version[0])
     assert convert_version_to_legacy_version(version) == expected_version
+
+
+class TestConvertToLegacyDomain:
+
+    def test_prod_domain(self):
+        domain = 'example.com'
+        expected = '.'.join(['legacy', domain])
+        assert convert_to_legacy_domain(domain) == expected
+
+    def test_dev_domain(self):
+        domain = 'dev.example.com'
+        expected = '-'.join(['legacy', domain])
+        assert convert_to_legacy_domain(domain) == expected


### PR DESCRIPTION
Collections on legacy do not check the database at every render. The default render path for 'latest' _does_ check, and update the pointer. By fetching that path, we cause the ZODB instance of the collection to be updated. Go ahead and do modules too - it'll pre-populate the varnish cache.

Addresses the (hopefully) last cause of  https://github.com/Connexions/nebuchadnezzar/issues/44

Also, change enqueing to use legacy domain - using the non-legacy is only really needed for PDF generation. This bypasses a problem w/ the non-legacy varnish config, as well.
