### PR TITLE
Support the publication of derived works to maintain parentage information

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,13 @@
 Change Log
 ==========
 
+3.4.0
+-----
+
+- Fix and support the publication of derived works to maintain parentage
+  information. This bit of information was being dropped during publication.
+  See https://github.com/Connexions/cnx-press/issues/126
+
 3.3.1
 -----
 

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -45,6 +45,8 @@ def publish_legacy_book(model, metadata, submission, db_conn):
         t.licenses.select()
         .where(t.licenses.c.url == metadata.license_url))
     licenseid = result.fetchone().licenseid
+
+    # Insert the module metadata
     result = db_conn.execute(t.modules.insert().values(
         uuid=existing_module.uuid,
         moduleid=metadata.id,
@@ -62,9 +64,9 @@ def publish_legacy_book(model, metadata, submission, db_conn):
         authors=metadata.authors,
         maintainers=metadata.maintainers,
         licensors=metadata.licensors,
-        # TODO metadata does not currently capture parentage
-        parent=None,
-        parentauthors=None,
+        # Carry over parentage information
+        parent=existing_module.parent,
+        parentauthors=existing_module.parentauthors,
         google_analytics=existing_module.google_analytics,
     ).returning(
         t.modules.c.module_ident,

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -60,9 +60,9 @@ def publish_legacy_page(model, metadata, submission, db_conn):
         authors=metadata.authors,
         maintainers=metadata.maintainers,
         licensors=metadata.licensors,
-        # TODO metadata does not currently capture parentage
-        parent=None,
-        parentauthors=None,
+        # Carry over parentage information
+        parent=existing_module.parent,
+        parentauthors=existing_module.parentauthors,
         google_analytics=existing_module.google_analytics,
     ).returning(
         t.modules.c.module_ident,

--- a/press/legacy_publishing/utils.py
+++ b/press/legacy_publishing/utils.py
@@ -1,3 +1,7 @@
+from litezip import (
+    Collection,
+    Module,
+)
 from litezip.main import COLLECTION_NSMAP
 from lxml import etree
 
@@ -5,8 +9,58 @@ from ..utils import convert_version_to_legacy_version
 
 
 __all__ = (
+    'replace_derived_from',
     'replace_id_and_version',
 )
+
+
+def replace_derived_from(model, derived_from_url):
+    """Does an inplace replacement or addition of the ``<md:derived-from>``
+    tag.
+
+    :param model: module
+    :type model: :class:`litezip.Collection` or :class:`litezip.Module`
+    :param derived_from_url: derived_from_url
+    :type derived_from_url: str
+
+    """
+    with model.file.open('rb') as fb:
+        xml = etree.parse(fb)
+    namespace_prefix = {
+        Module: 'c',
+        Collection: 'col',
+    }[type(model)]
+
+    # Lookup the metadata element
+    metadata_elm = xml.xpath(
+        '//{}:metadata'.format(namespace_prefix),
+        namespaces=COLLECTION_NSMAP,
+    )[0]
+    # Create the new derived-from element
+    derived_from_elm = etree.fromstring(
+        '<derived-from xmlns="{}" url="{}"/>'
+        .format(
+            COLLECTION_NSMAP['md'],
+            derived_from_url,
+        )
+    )
+
+    try:
+        found_derived_from_elm = xml.xpath(
+            '//md:derived-from',
+            namespaces=COLLECTION_NSMAP,
+        )[0]
+    except IndexError:
+        pass
+    else:
+        # Remove the element in favor of our newly created one
+        metadata_elm.remove(found_derived_from_elm)
+    finally:
+        # Append the element to metadata
+        metadata_elm.append(derived_from_elm)
+
+    with model.file.open('wb') as fb:
+        fb.write(etree.tostring(xml))
 
 
 def replace_id_and_version(model, id, version):

--- a/tests/_templates/collection.xml
+++ b/tests/_templates/collection.xml
@@ -50,6 +50,9 @@
     </md:subjectlist>
     <md:abstract>{{ metadata.abstract }}</md:abstract>
     <md:language>en</md:language>
+    {%- if metadata.derived_from %}
+    <md:derived-from url="http://cnx.org/content/{{metadata.derived_from.id}}/{{metadata.derived_from.version}}"/>
+    {%- endif %}
   </metadata>
 
   <col:parameters>

--- a/tests/_templates/module.xml
+++ b/tests/_templates/module.xml
@@ -40,6 +40,9 @@
   </md:subjectlist>
   <md:abstract>{{ metadata.abstract }}</md:abstract>
   <md:language>en</md:language>
+  {%- if metadata.derived_from %}
+  <md:derived-from url="http://cnx.org/content/{{metadata.derived_from.id}}/{{metadata.derived_from.version}}"/>
+  {%- endif %}
 </metadata>
 
 <content>

--- a/tests/functional/legacy_publishing/test_collection.py
+++ b/tests/functional/legacy_publishing/test_collection.py
@@ -44,6 +44,7 @@ def test_publish_legacy_book(
     collection, tree, modules = content_util.rebuild_collection(collection,
                                                                 tree)
 
+    # TARGET
     with db_engines['common'].begin() as conn:
         now = conn.execute('SELECT CURRENT_TIMESTAMP as now').fetchone().now
         (id, version), ident = publish_legacy_book(
@@ -119,3 +120,93 @@ def test_publish_legacy_book(
         .bindparams(module_ident=ident))
     inserted_tree = db_engines['common'].execute(stmt).fetchone()[0]
     compare_legacy_tree_similarity(inserted_tree['contents'], tree)
+
+
+def test_publish_derived_legacy_book(
+        content_util, persist_util, app, db_engines, db_tables):
+    # Insert initial collection and modules.
+    resources = list([content_util.gen_resource() for x in range(0, 2)])
+    collection, tree, modules = content_util.gen_collection(
+        resources=resources
+    )
+    modules = list([persist_util.insert_module(m) for m in modules])
+    collection, tree, modules = content_util.rebuild_collection(collection,
+                                                                tree)
+    collection = persist_util.insert_collection(collection)
+    metadata = parse_collection_metadata(collection)
+
+    # Derive a copy of the collection
+    derived_collection = persist_util.derive_from(collection)
+    derived_metadata = parse_collection_metadata(derived_collection)
+
+    # Collect control data for non-legacy metadata
+    stmt = (
+        db_tables.modules.select()
+        .where(db_tables.modules.c.moduleid == derived_metadata.id)
+    )
+    control_metadata = db_engines['common'].execute(stmt).fetchone()
+
+    # TARGET
+    with db_engines['common'].begin() as conn:
+        now = conn.execute('SELECT CURRENT_TIMESTAMP as now').fetchone().now
+        (id, version), ident = publish_legacy_book(
+            derived_collection,
+            derived_metadata,
+            ('user1', 'test publish',),
+            conn,
+        )
+
+    # Lookup parent collection's metadata (ident and authors)
+    # for parentage checks against the derived-copy metadata.
+    stmt = (
+        db_tables.latest_modules
+        .select()
+        .where(db_tables.latest_modules.c.moduleid == collection.id)
+    )
+    parent_metadata_result = db_engines['common'].execute(stmt).fetchone()
+
+    # Check core metadata insertion
+    stmt = (
+        db_tables.modules.join(db_tables.abstracts)
+        .select()
+        .where(db_tables.modules.c.module_ident == ident)
+    )
+    result = db_engines['common'].execute(stmt).fetchone()
+    assert result.uuid == control_metadata.uuid
+    assert result.major_version == 2
+    assert result.minor_version == 1
+    assert result.version == '1.2'
+    assert result.abstract == derived_metadata.abstract
+    assert result.created == parse_date(derived_metadata.created)
+    assert result.revised == now
+    assert result.portal_type == 'Collection'
+    assert result.name == derived_metadata.title
+    assert result.licenseid == 13
+    assert result.print_style == derived_metadata.print_style
+    assert result.submitter == 'user1'
+    assert result.submitlog == 'test publish'
+    assert result.authors == list(derived_metadata.authors)
+    assert result.maintainers == list(derived_metadata.maintainers)
+    assert result.licensors == list(derived_metadata.licensors)
+    assert result.google_analytics == GOOGLE_ANALYTICS_CODE
+
+    # Check for derived metadata (parent and parent authors)
+    assert result.parent == parent_metadata_result.module_ident
+    assert result.parentauthors == parent_metadata_result.authors
+
+    # Check the derived-from metadata tag was correctly inserted
+    # into the document.
+    stmt = (
+        db_tables.module_files
+        .join(db_tables.files)
+        .select()
+        .where(db_tables.module_files.c.module_ident == ident)
+        .where(db_tables.module_files.c.filename == 'collection.xml')
+    )
+    collection_doc = db_engines['common'].execute(stmt).fetchone()
+    expected = bytes(
+        ('<md:derived-from url="http://cnx.org/content/{}/{}"/>'
+         .format(metadata.id, metadata.version)),
+        'utf-8',
+    )
+    assert expected in collection_doc.file

--- a/tests/functional/legacy_publishing/test_module.py
+++ b/tests/functional/legacy_publishing/test_module.py
@@ -25,6 +25,7 @@ def test_publish_revision_to_legacy_page(
     )
     control_metadata = db_engines['common'].execute(stmt).fetchone()
 
+    # TARGET
     with db_engines['common'].begin() as conn:
         now = conn.execute('SELECT CURRENT_TIMESTAMP as now').fetchone().now
         (id, version), ident = publish_legacy_page(
@@ -93,3 +94,86 @@ def test_publish_revision_to_legacy_page(
         # for this project, but order of insertion matters in order for
         # the references to be rewritten.
         assert '/resources/{}'.format(resource.sha1) in html_content
+
+
+def test_publish_derived_legacy_page(
+        content_util, persist_util, app, db_engines, db_tables):
+    resources = list([content_util.gen_resource() for x in range(0, 2)])
+    module = content_util.gen_module(resources=resources)
+    module = persist_util.insert_module(module)
+
+    metadata = parse_module_metadata(module)
+
+    # Derive a copy of the collection
+    derived_module = persist_util.derive_from(module)
+    derived_metadata = parse_module_metadata(derived_module)
+
+    # Collect control data for non-legacy metadata
+    stmt = (
+        db_tables.modules.select()
+        .where(db_tables.modules.c.moduleid == derived_metadata.id)
+    )
+    control_metadata = db_engines['common'].execute(stmt).fetchone()
+
+    # TARGET
+    with db_engines['common'].begin() as conn:
+        now = conn.execute('SELECT CURRENT_TIMESTAMP as now').fetchone().now
+        (id, version), ident = publish_legacy_page(
+            derived_module,
+            derived_metadata,
+            ('user1', 'test publish',),
+            conn,
+        )
+
+    # Lookup parent's metadata (ident and authors)
+    # for parentage checks against the derived-copy metadata.
+    stmt = (
+        db_tables.latest_modules
+        .select()
+        .where(db_tables.latest_modules.c.moduleid == module.id)
+    )
+    parent_metadata_result = db_engines['common'].execute(stmt).fetchone()
+
+    # Check core metadata insertion
+    stmt = (
+        db_tables.modules.join(db_tables.abstracts)
+        .select()
+        .where(db_tables.modules.c.module_ident == ident)
+    )
+    result = db_engines['common'].execute(stmt).fetchone()
+    assert result.version == '1.2'
+    assert result.uuid == control_metadata.uuid
+    assert result.major_version == 2
+    assert result.minor_version is None
+    assert result.abstract == derived_metadata.abstract
+    assert result.created == parse_date(metadata.created)
+    assert result.revised == now
+    assert result.portal_type == 'Module'
+    assert result.name == derived_metadata.title
+    assert result.licenseid == 13
+    assert result.submitter == 'user1'
+    assert result.submitlog == 'test publish'
+    assert result.authors == list(derived_metadata.authors)
+    assert result.maintainers == list(derived_metadata.maintainers)
+    assert result.licensors == list(derived_metadata.licensors)
+    assert result.google_analytics == GOOGLE_ANALYTICS_CODE
+
+    # Check for derived metadata (parent and parent authors)
+    assert result.parent == parent_metadata_result.module_ident
+    assert result.parentauthors == parent_metadata_result.authors
+
+    # Check for file insertion
+    stmt = (
+        db_tables.module_files
+        .join(db_tables.files)
+        .select()
+        .where(db_tables.module_files.c.module_ident == ident)
+        .where(db_tables.module_files.c.filename == 'index.cnxml')
+    )
+    module_doc = db_engines['common'].execute(stmt).fetchone()
+    expected = bytes(
+        ('<md:derived-from url="http://cnx.org/content/{}/{}"/>'
+         .format(metadata.id, metadata.version)),
+        'utf-8',
+    )
+    assert expected in module_doc.file

--- a/tests/unit/legacy_publishing/test_utils.py
+++ b/tests/unit/legacy_publishing/test_utils.py
@@ -1,4 +1,5 @@
 from press.legacy_publishing.utils import (
+    replace_derived_from,
     replace_id_and_version,
 )
 
@@ -16,3 +17,38 @@ def test_replace_id_and_version(content_util):
         text = fb.read()
     assert id in text
     assert '1.{}'.format(version[0]) in text
+
+
+class TestReplaceDerivedFrom:
+
+    def test_create(self, content_util):
+        module = content_util.gen_module()
+        id = '$$$_id_$$$'
+        version = '$.%'
+        url = 'http://cnx.org/content/{}/{}'.format(id, version)
+
+        # Call the target
+        replace_derived_from(module, url)
+
+        # Check the derived-from was replaced
+        with module.file.open('r') as fb:
+            text = fb.read()
+        expected = '<md:derived-from url="{}"/>'.format(url)
+        assert expected in text
+
+    def test_replace(self, content_util):
+        original_module = content_util.gen_module()
+        module = content_util.gen_module(derived_from=original_module)
+        id = '$$$_id_$$$'
+        version = '$.%'
+
+        url = 'http://cnx.org/content/{}/{}'.format(id, version)
+
+        # Call the target
+        replace_derived_from(module, url)
+
+        # Check the derived-from was replaced
+        with module.file.open('r') as fb:
+            text = fb.read()
+        expected = '<md:derived-from url="{}"/>'.format(url)
+        assert expected in text


### PR DESCRIPTION
The implementation essentially ignores `<md:derived-from ...>...</md:derived-from>`. The database is the source of truth on derivation. Instead of reading this mutable info from the file's contents, the existing record (previous version) is consulted. The parentage information is then carried over to the contextual publication.

The `<md:derived-from url="..."/>` tag is rewritten before insertion into the database. This will ensure the correct info is within the document even though it is ignored by Press.

I choose to use `<md:derived-from url="..."/>` over `<md:derived-from url="...">... other metadata ...</md:derived-from>` because 1) the data is redundant 2) there isn't consistent use of the full form in the content (i.e. modules use this short form) and 3) because it was simplest.

Addresses #126 