### PR TITLE
Refactor subscriber tests to use a common request fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from copy import copy, deepcopy
 from contextlib import contextmanager
 
 import jinja2
+import pretend
 import pytest
 from cnxdb.init import init_db
 from litezip import Collection, Module
@@ -235,6 +236,19 @@ def testing(_init_database, db_engines, db_tables_session_scope):
     db_engines['common'].execute(
         t.persons.insert(),
         [dict(zip(column_names, x)) for x in PERSONS])
+
+
+@pytest.fixture
+def pretend_logger():
+    info = pretend.call_recorder(lambda *a, **kw: None)
+    debug = pretend.call_recorder(lambda *a, **kw: None)
+    exception = pretend.call_recorder(lambda *a, **kw: None)
+    logger = pretend.stub(
+        info=info,
+        debug=debug,
+        exception=exception,
+    )
+    return logger
 
 
 # ###

--- a/tests/unit/subscribers/conftest.py
+++ b/tests/unit/subscribers/conftest.py
@@ -1,0 +1,17 @@
+import pretend
+import pytest
+
+
+@pytest.fixture
+def event_request(pretend_logger):
+    # Stub out the raven client
+    captureException = pretend.call_recorder(lambda: None)
+    raven_client = pretend.stub(captureException=captureException)
+    # Create an event with a stub request
+    request = pretend.stub(
+        domain='example.org',
+        scheme='mock',
+        log=pretend_logger,
+        raven_client=raven_client,
+    )
+    return request

--- a/tests/unit/subscribers/test_legacy_enqueue.py
+++ b/tests/unit/subscribers/test_legacy_enqueue.py
@@ -10,23 +10,19 @@ from tests.helpers import (
 )
 
 
-def test(requests_mock):
+def test(requests_mock, event_request):
     request_callback = pretend.call_recorder(
         lambda request, context: 'enqueued')
     # mock the request to enqueue
     requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
 
-    # stub out the logger
-    logger_info = pretend.call_recorder(lambda *a, **kw: None)
-    logger = pretend.stub(info=logger_info)
     # Create an event with a stub request
     ids = [
         ('m12345', (2, None)),
         ('m54321', (4, None)),
         ('col32154', (5, 1)),
     ]
-    request = pretend.stub(domain='example.org', scheme='mock', log=logger)
-    event = LegacyPublicationFinished(ids, request)
+    event = LegacyPublicationFinished(ids, event_request)
 
     # Call the subcriber
     legacy_enqueue(event)
@@ -43,12 +39,12 @@ def test(requests_mock):
         assert url == request.url
 
     # Check for logging
-    assert len(logger_info.calls) == len(ids)
+    assert len(event_request.log.info.calls) == len(ids)
     for i, (id, ver) in enumerate(sorted(ids)):
-        assert id in logger_info.calls[i].args[0]
+        assert id in event_request.log.info.calls[i].args[0]
 
 
-def test_failed_request_and_retry_failed(requests_mock):
+def test_failed_request_and_retry_failed(requests_mock, event_request):
     ids = [
         ('m12345', (2, None)),
         ('m54321', (4, None)),
@@ -64,37 +60,24 @@ def test_failed_request_and_retry_failed(requests_mock):
     # mock a problem request to enqueue
     requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
 
-    # stub out the raven client
-    captureException = pretend.call_recorder(lambda: None)
-    raven_client = pretend.stub(captureException=captureException)
-    # stub out the logger
-    logger_info = pretend.call_recorder(lambda *a, **kw: None)
-    logger_exception = pretend.call_recorder(lambda *a, **kw: None)
-    logger = pretend.stub(
-        info=logger_info,
-        exception=logger_exception,
-    )
-    # Create an event with a stub request
-    request = pretend.stub(domain='example.org', scheme='mock',
-                           log=logger, raven_client=raven_client)
-    event = LegacyPublicationFinished(ids, request)
+    event = LegacyPublicationFinished(ids, event_request)
 
     # Call the subcriber
     legacy_enqueue(event)
 
     # Check raven was used...
-    assert captureException.calls
+    assert event_request.raven_client.captureException.calls
 
     # Check for logging
-    assert logger_exception.calls == [
+    assert event_request.log.exception.calls == [
         pretend.call("problem enqueuing '{}'".format(ids[1][0])),
     ]
-    assert len(logger_info.calls) == len(ids) - 1
+    assert len(event_request.log.info.calls) == len(ids) - 1
     for i, (id, ver) in enumerate(sorted(ids)[:-1]):
-        assert id in logger_info.calls[i].args[0]
+        assert id in event_request.log.info.calls[i].args[0]
 
 
-def test_failed_request_and_retry_success(requests_mock):
+def test_failed_request_and_retry_success(requests_mock, event_request):
     ids = [
         ('m12345', (2, None)),
         ('m54321', (4, None)),
@@ -111,26 +94,13 @@ def test_failed_request_and_retry_success(requests_mock):
     # mock a problem request to enqueue
     requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
 
-    # stub out the raven client
-    captureException = pretend.call_recorder(lambda: None)
-    raven_client = pretend.stub(captureException=captureException)
-    # stub out the logger
-    logger_info = pretend.call_recorder(lambda *a, **kw: None)
-    logger_exception = pretend.call_recorder(lambda *a, **kw: None)
-    logger = pretend.stub(
-        info=logger_info,
-        exception=logger_exception,
-    )
-    # Create an event with a stub request
-    request = pretend.stub(domain='example.org', scheme='mock',
-                           log=logger, raven_client=raven_client)
-    event = LegacyPublicationFinished(ids, request)
+    event = LegacyPublicationFinished(ids, event_request)
 
     # Call the subcriber
     legacy_enqueue(event)
 
     # Check raven was used...
-    assert captureException.calls
+    assert event_request.raven_client.captureException.calls
 
     # Check for logging
-    assert logger_exception.calls == []
+    assert event_request.log.exception.calls == []

--- a/tests/unit/subscribers/test_legacy_update_latest.py
+++ b/tests/unit/subscribers/test_legacy_update_latest.py
@@ -10,23 +10,19 @@ from tests.helpers import (
 )
 
 
-def test(requests_mock):
+def test(requests_mock, event_request):
     request_callback = pretend.call_recorder(
         lambda request, context: 'updated')
     # mock the request to enqueue
     requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
 
-    # stub out the logger
-    logger_info = pretend.call_recorder(lambda *a, **kw: None)
-    logger = pretend.stub(info=logger_info)
     # Create an event with a stub request
     ids = [
         ('m12345', (2, None)),
         ('m54321', (4, None)),
         ('col32154', (5, 1)),
     ]
-    request = pretend.stub(domain='example.org', scheme='mock', log=logger)
-    event = LegacyPublicationFinished(ids, request)
+    event = LegacyPublicationFinished(ids, event_request)
 
     # Call the subcriber
     legacy_update_latest(event)
@@ -42,12 +38,12 @@ def test(requests_mock):
         assert url == request.url
 
     # Check for logging
-    assert len(logger_info.calls) == len(ids)
+    assert len(event_request.log.info.calls) == len(ids)
     for i, (id, ver) in enumerate(sorted(ids)):
-        assert id in logger_info.calls[i].args[0]
+        assert id in event_request.log.info.calls[i].args[0]
 
 
-def test_failed_request_and_retry_failed(requests_mock):
+def test_failed_request_and_retry_failed(requests_mock, event_request):
     ids = [
         ('m12345', (2, None)),
         ('m54321', (4, None)),
@@ -63,37 +59,24 @@ def test_failed_request_and_retry_failed(requests_mock):
     # mock a problem request to enqueue
     requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
 
-    # stub out the raven client
-    captureException = pretend.call_recorder(lambda: None)
-    raven_client = pretend.stub(captureException=captureException)
-    # stub out the logger
-    logger_info = pretend.call_recorder(lambda *a, **kw: None)
-    logger_exception = pretend.call_recorder(lambda *a, **kw: None)
-    logger = pretend.stub(
-        info=logger_info,
-        exception=logger_exception,
-    )
-    # Create an event with a stub request
-    request = pretend.stub(domain='example.org', scheme='mock',
-                           log=logger, raven_client=raven_client)
-    event = LegacyPublicationFinished(ids, request)
+    event = LegacyPublicationFinished(ids, event_request)
 
     # Call the subcriber
     legacy_update_latest(event)
 
     # Check raven was used...
-    assert captureException.calls
+    assert event_request.raven_client.captureException.calls
 
     # Check for logging
-    assert logger_exception.calls == [
+    assert event_request.log.exception.calls == [
         pretend.call("problem fetching '{}'".format(ids[1][0])),
     ]
-    assert len(logger_info.calls) == len(ids) - 1
+    assert len(event_request.log.info.calls) == len(ids) - 1
     for i, (id, ver) in enumerate(sorted(ids)[:-1]):
-        assert id in logger_info.calls[i].args[0]
+        assert id in event_request.log.info.calls[i].args[0]
 
 
-def test_failed_request_and_retry_success(requests_mock):
+def test_failed_request_and_retry_success(requests_mock, event_request):
     ids = [
         ('m12345', (2, None)),
         ('m54321', (4, None)),
@@ -110,26 +93,13 @@ def test_failed_request_and_retry_success(requests_mock):
     # mock a problem request to enqueue
     requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
 
-    # stub out the raven client
-    captureException = pretend.call_recorder(lambda: None)
-    raven_client = pretend.stub(captureException=captureException)
-    # stub out the logger
-    logger_info = pretend.call_recorder(lambda *a, **kw: None)
-    logger_exception = pretend.call_recorder(lambda *a, **kw: None)
-    logger = pretend.stub(
-        info=logger_info,
-        exception=logger_exception,
-    )
-    # Create an event with a stub request
-    request = pretend.stub(domain='example.org', scheme='mock',
-                           log=logger, raven_client=raven_client)
-    event = LegacyPublicationFinished(ids, request)
+    event = LegacyPublicationFinished(ids, event_request)
 
     # Call the subcriber
     legacy_update_latest(event)
 
     # Check raven was used...
-    assert captureException.calls
+    assert event_request.raven_client.captureException.calls
 
     # Check for logging
-    assert logger_exception.calls == []
+    assert event_request.log.exception.calls == []

--- a/tests/unit/subscribers/test_purge_cache.py
+++ b/tests/unit/subscribers/test_purge_cache.py
@@ -12,7 +12,7 @@ from press.subscribers.purge_cache import (
 
 class TestPurgeCache:
 
-    def test(self, requests_mock):
+    def test(self, requests_mock, event_request):
         request_callback = pretend.call_recorder(
             lambda request, context: 'purged')
         # mock the request to purge
@@ -22,22 +22,13 @@ class TestPurgeCache:
             text=request_callback,
         )
 
-        # stub out the logger
-        logger_info = pretend.call_recorder(lambda *a, **kw: None)
-        logger_debug = pretend.call_recorder(lambda *a, **kw: None)
-        logger = pretend.stub(info=logger_info, debug=logger_debug)
         # Create an event with a stub request
         ids = [
             ('m12345', (2, None)),
             ('m54321', (4, None)),
             ('col32154', (5, 1)),
         ]
-        request = pretend.stub(
-            domain='example.org',
-            scheme='mock',
-            log=logger,
-        )
-        event = LegacyPublicationFinished(ids, request)
+        event = LegacyPublicationFinished(ids, event_request)
 
         # Call the subcriber
         purge_cache(event)
@@ -53,16 +44,16 @@ class TestPurgeCache:
         assert url == sent_request.url
 
         # Check for logging
-        assert logger_debug.calls == [
+        assert event_request.log.debug.calls == [
             pretend.call("purge url:  {}".format(url)),
         ]
-        assert logger_info.calls == [
+        assert event_request.log.info.calls == [
             pretend.call("purged urls for the 'latest' version of '{}' "
                          "on the legacy domain"
                          .format(', '.join(map(lambda x: x[0], ids)))),
         ]
 
-    def test_failed_request(self, requests_mock):
+    def test_failed_request(self, requests_mock, event_request):
         # mock the failing request to purge
         requests_mock.register_uri(
             'PURGE_REGEXP',
@@ -70,37 +61,19 @@ class TestPurgeCache:
             exc=requests.exceptions.ConnectTimeout,
         )
 
-        # stub out the raven client
-        captureException = pretend.call_recorder(lambda: None)
-        raven_client = pretend.stub(captureException=captureException)
-        # stub out the logger
-        logger_info = pretend.call_recorder(lambda *a, **kw: None)
-        logger_debug = pretend.call_recorder(lambda *a, **kw: None)
-        logger_exception = pretend.call_recorder(lambda *a, **kw: None)
-        logger = pretend.stub(
-            info=logger_info,
-            debug=logger_debug,
-            exception=logger_exception,
-        )
         # Create an event with a stub request
         ids = [
             ('m12345', (2, None)),
             ('m54321', (4, None)),
             ('col32154', (5, 1)),
         ]
-        request = pretend.stub(
-            domain='example.org',
-            scheme='mock',
-            log=logger,
-            raven_client=raven_client,
-        )
-        event = LegacyPublicationFinished(ids, request)
+        event = LegacyPublicationFinished(ids, event_request)
 
         # Call the subcriber
         purge_cache(event)
 
         # Check raven was used...
-        assert captureException.calls
+        assert event_request.raven_client.captureException.calls
 
         known_base_url = 'mock://legacy.example.org'
         url = (
@@ -108,13 +81,13 @@ class TestPurgeCache:
             .format(known_base_url, '|'.join([x[0] for x in ids]))
         )
         # Check for logging
-        assert logger_debug.calls == []
-        assert logger_info.calls == []
-        assert logger_exception.calls == [
+        assert event_request.log.debug.calls == []
+        assert event_request.log.info.calls == []
+        assert event_request.log.exception.calls == [
             pretend.call('problem purging with {}'.format(url)),
         ]
 
-    def test_large_publication(self, requests_mock):
+    def test_large_publication(self, requests_mock, event_request):
 
         def _make_callback(text='purged', is_exception=False):
             def callback(request, context):
@@ -141,18 +114,6 @@ class TestPurgeCache:
             response_list,
         )
 
-        # stub out the raven client
-        captureException = pretend.call_recorder(lambda: None)
-        raven_client = pretend.stub(captureException=captureException)
-        # stub out the logger
-        logger_info = pretend.call_recorder(lambda *a, **kw: None)
-        logger_debug = pretend.call_recorder(lambda *a, **kw: None)
-        logger_exception = pretend.call_recorder(lambda *a, **kw: None)
-        logger = pretend.stub(
-            info=logger_info,
-            debug=logger_debug,
-            exception=logger_exception,
-        )
         # Create an event with a stub request
         ids = [
             ('m12', (2, None)),
@@ -179,25 +140,19 @@ class TestPurgeCache:
             ('col21', (5, 1)),
             ('col52', (5, 1)),
         ]
-        request = pretend.stub(
-            domain='example.org',
-            scheme='mock',
-            log=logger,
-            raven_client=raven_client,
-        )
-        event = LegacyPublicationFinished(ids, request)
+        event = LegacyPublicationFinished(ids, event_request)
 
         # Call the subcriber
         purge_cache(event)
 
         # Check raven was used...
-        assert len(captureException.calls) == 1
+        assert len(event_request.raven_client.captureException.calls) == 1
 
         # Check for logging, but not the details, because that's not the
         # focus of this particular test.
-        assert len(logger_debug.calls) == 2
-        assert len(logger_info.calls) == 2
-        assert len(logger_exception.calls) == 1
+        assert len(event_request.log.debug.calls) == 2
+        assert len(event_request.log.info.calls) == 2
+        assert len(event_request.log.exception.calls) == 1
 
         # Check the requests have the correct set of ids in them.
         just_ids = list(map(lambda x: x[0], ids))


### PR DESCRIPTION
Simple refactor, no logic changed in the application itself