### PR TITLE
Enable squash merge for all pull requests

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,3 +15,15 @@ repository:
 
   # Either `true` to enable the wiki for this repository, `false` to disable it.
   has_wiki: true
+  
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: false
+
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: false


### PR DESCRIPTION
I still think rebase merge is best. I'd keep it enabled, but I'm not sure if people would really know when to validly use it vs squash merge, so let's just do squash.