### PR TITLE
Add a pre-commit configuration for general use

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: flake8
+  # - repo: https://github.com/asottile/add-trailing-comma
+  #   rev: v0.6.4
+  #   hooks:
+  #     - id: add-trailing-comma


### PR DESCRIPTION
This simply adds the general use pre-commit configuration for this repo. Documentation on how to use this would be handy, but isn't absolutely required for use. We'll add that in a bit later.

See also https://github.com/Connexions/nebuchadnezzar/pull/68 for a similar PR.