### PR TITLE
Adjust some event subscriber logic to call async Celery tasks

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -7,6 +7,9 @@ Change Log
 
 - Add Celery to the project to move non-critical-path event handling logic
   to asynchronous tasks.
+- Revise the subscriber communication to update the legacy 'latest' version.
+  This procedure is now an asynchronous out-of-band task. The custom
+  request retry behavior has been removed in favor of Celery's retry behavior.
 
 3.4.2
 -----

--- a/press/outofband.py
+++ b/press/outofband.py
@@ -1,0 +1,27 @@
+"""\
+Out-of-band asynchronous task (a.k.a. Celery tasks).
+
+"""
+import requests
+
+from press.tasks import task
+
+
+REQUESTS_TIMEOUT = (1, 120)  # (<connect>, <read>)
+
+
+@task(bind=True, max_retries=3, default_retry_delay=5)
+def make_request(self, url):
+    with requests.Session() as session:
+        try:
+            session.get(url, timeout=REQUESTS_TIMEOUT)
+        except requests.exceptions.RequestException as exc:
+            pyramid_request = self.get_pyramid_request()
+            try:
+                self.retry(exc=exc)
+            except self.MaxRetriesExceededError:
+                # max_retries will stop us from doing a too many retries.
+                pyramid_request.raven_client.captureException()
+                raise
+            msg = "problem requesting '{}'".format(url)
+            pyramid_request.log.exception(msg)

--- a/press/subscribers/legacy_enqueue.py
+++ b/press/subscribers/legacy_enqueue.py
@@ -1,44 +1,36 @@
-import requests
-
+from press.outofband import make_request
 from press.utils import convert_to_legacy_domain
+
+
+# The url is built specifically for collections, but works for modules,
+# because the code for modules doesn't care about the extra options.
+URL_TMPLT = (
+    '{base_url}/content/{module_id}/{version}'
+    '/enqueue?colcomplete=True&collxml=True'
+)
 
 
 # subscriber for press.events.LegacyPublicationFinished
 def legacy_enqueue(event):
     logger = event.request.log
 
+    # Get the celery task object
+    task_path = '.'.join([make_request.__module__, make_request.__name__])
+    _make_request = event.request.registry.celery_app.tasks[task_path]
+
     # Build the enqueue RPC url
     domain = convert_to_legacy_domain(event.request.domain)
     scheme = event.request.scheme
     base_url = '{}://{}'.format(scheme, domain)
-    # The url is built specifically for collections, but works for modules,
-    # because the code for modules doesn't care about the extra options.
-    url_tmplt = (
-        '{base_url}/content/{module_id}/{version}'
-        '/enqueue?colcomplete=True&collxml=True'
-    )
 
-    timeout = (1, 20)  # (<connect>, <read>)
-    ids = sorted(event.ids)
-    with requests.Session() as session:
-        for id, ver in ids:
-            version = '1.{}'.format(ver[0])
-            url = url_tmplt.format(
-                base_url=base_url,
-                module_id=id,
-                version=version,
-            )
-            try:
-                session.get(url, timeout=timeout)
-            except requests.exceptions.RequestException:
-                event.request.raven_client.captureException()
-                # try one more time
-                try:
-                    session.get(url, timeout=timeout)
-                except requests.exceptions.RequestException:
-                    event.request.raven_client.captureException()
-                    logger.exception("problem enqueuing '{}'".format(id))
-                    continue
-                continue
-            logger.info("enqueued '{}' within the legacy system"
-                        .format(id))
+    for id, ver in sorted(event.ids):
+        version = '1.{}'.format(ver[0])
+        url = URL_TMPLT.format(
+            base_url=base_url,
+            module_id=id,
+            version=version,
+        )
+        _make_request.delay(url)
+        logger.info(
+            "asynchronously enqueued '{}' within the legacy system".format(id)
+        )

--- a/press/subscribers/legacy_update_latest.py
+++ b/press/subscribers/legacy_update_latest.py
@@ -1,6 +1,27 @@
 import requests
 
+from press.tasks import task
 from press.utils import convert_to_legacy_domain
+
+
+TIMEOUT = (1, 120)  # (<connect>, <read>)
+URL_TMPLT = ('{base_url}/content/{module_id}/latest')
+
+
+@task(bind=True, max_retries=3, default_retry_delay=5)
+def poke_latest(self, url):
+    with requests.Session() as session:
+        try:
+            session.get(url, timeout=TIMEOUT)
+        except requests.exceptions.RequestException as exc:
+            pyramid_request = self.get_pyramid_request()
+            try:
+                self.retry(exc=exc)
+            except self.MaxRetriesExceededError:
+                # max_retries will stop us from doing a too many retries.
+                pyramid_request.raven_client.captureException()
+                raise
+            pyramid_request.log.exception("problem fetching '{}'".format(url))
 
 
 # subscriber for press.events.LegacyPublicationFinished
@@ -12,27 +33,19 @@ def legacy_update_latest(event):
     # Build the latest content url
     scheme = event.request.scheme
     base_url = '{}://{}'.format(scheme, domain)
-    url_tmplt = ('{base_url}/content/{module_id}/latest')
 
-    timeout = (1, 120)  # (<connect>, <read>)
+    # Get the celery task object
+    task_name = 'press.subscribers.legacy_update_latest.poke_latest'
+    poke_latest = event.request.registry.celery_app.tasks[task_name]
+
     ids = sorted(event.ids)
-    with requests.Session() as session:
-        for id, _ in ids:
-            url = url_tmplt.format(
-                base_url=base_url,
-                module_id=id,
-            )
-            try:
-                session.get(url, timeout=timeout)
-            except requests.exceptions.RequestException:
-                event.request.raven_client.captureException()
-                # try one more time
-                try:
-                    session.get(url, timeout=timeout)
-                except requests.exceptions.RequestException:
-                    event.request.raven_client.captureException()
-                    logger.exception("problem fetching '{}'".format(id))
-                    continue
-                continue
-            logger.info("fetched '{}/latest' within the legacy system"
-                        .format(id))
+    for id, _ in ids:
+        logger.info(
+            "async request made to poke '{}/latest' on the legacy system"
+            .format(id)
+        )
+        url = URL_TMPLT.format(
+            base_url=base_url,
+            module_id=id,
+        )
+        poke_latest.delay(url)

--- a/press/subscribers/legacy_update_latest.py
+++ b/press/subscribers/legacy_update_latest.py
@@ -1,27 +1,8 @@
-import requests
-
-from press.tasks import task
+from press.outofband import make_request
 from press.utils import convert_to_legacy_domain
 
 
-TIMEOUT = (1, 120)  # (<connect>, <read>)
 URL_TMPLT = ('{base_url}/content/{module_id}/latest')
-
-
-@task(bind=True, max_retries=3, default_retry_delay=5)
-def poke_latest(self, url):
-    with requests.Session() as session:
-        try:
-            session.get(url, timeout=TIMEOUT)
-        except requests.exceptions.RequestException as exc:
-            pyramid_request = self.get_pyramid_request()
-            try:
-                self.retry(exc=exc)
-            except self.MaxRetriesExceededError:
-                # max_retries will stop us from doing a too many retries.
-                pyramid_request.raven_client.captureException()
-                raise
-            pyramid_request.log.exception("problem fetching '{}'".format(url))
 
 
 # subscriber for press.events.LegacyPublicationFinished
@@ -35,8 +16,8 @@ def legacy_update_latest(event):
     base_url = '{}://{}'.format(scheme, domain)
 
     # Get the celery task object
-    task_name = 'press.subscribers.legacy_update_latest.poke_latest'
-    poke_latest = event.request.registry.celery_app.tasks[task_name]
+    task_path = '.'.join([make_request.__module__, make_request.__name__])
+    _make_request = event.request.registry.celery_app.tasks[task_path]
 
     ids = sorted(event.ids)
     for id, _ in ids:
@@ -48,4 +29,4 @@ def legacy_update_latest(event):
             base_url=base_url,
             module_id=id,
         )
-        poke_latest.delay(url)
+        _make_request.delay(url)

--- a/press/subscribers/purge_cache.py
+++ b/press/subscribers/purge_cache.py
@@ -1,12 +1,9 @@
-import requests
-
+from press.outofband import make_request
 from press.utils import convert_to_legacy_domain
 
 
 # Range of the sequence of ids to put into a purge url
 ID_CHUNK_SIZE = 10
-# Used by the quest
-TIMEOUT = (1, 5)  # (<connect>, <read>)
 
 
 def _gen_purge_url(base, ids):
@@ -18,16 +15,14 @@ def _gen_purge_url(base, ids):
     return '{}/content/{}/latest.*$'.format(base, regex_ids)
 
 
-def _make_request(url):
-    """requests.Request factory for creating a purge request"""
-    purge_req = requests.Request('PURGE_REGEXP', url)
-    return purge_req.prepare()
-
-
 # subscriber for press.events.LegacyPublicationFinished
 def purge_cache(event):
     logger = event.request.log
     just_ids = list(map(lambda x: x[0], event.ids))
+
+    # Get the celery task object
+    task_path = '.'.join([make_request.__module__, make_request.__name__])
+    _make_request = event.request.registry.celery_app.tasks[task_path]
 
     # Build the legacy domain from the current request domain.
     domain = convert_to_legacy_domain(event.request.domain)
@@ -35,22 +30,18 @@ def purge_cache(event):
     scheme = event.request.scheme
     base_url = '{}://{}'.format(scheme, domain)
 
-    with requests.Session() as session:
-        start = 0
-        range_stop = len(just_ids) + ID_CHUNK_SIZE
-        for end in range(ID_CHUNK_SIZE, range_stop, ID_CHUNK_SIZE):
-            ids = just_ids[start:end]
-            url = _gen_purge_url(base_url, ids)
-            req = _make_request(url)
-            try:
-                session.send(req, timeout=TIMEOUT)
-            except requests.exceptions.RequestException:
-                event.request.raven_client.captureException()
-                logger.exception("problem purging with {}".format(url))
-            else:
-                logger.debug("purge url:  {}".format(url))
-                logger.info("purged urls for the 'latest' version of '{}' "
-                            "on the legacy domain"
-                            .format(', '.join(ids)))
-            finally:
-                start = end
+    start = 0
+    range_stop = len(just_ids) + ID_CHUNK_SIZE
+    for end in range(ID_CHUNK_SIZE, range_stop, ID_CHUNK_SIZE):
+        ids = just_ids[start:end]
+        url = _gen_purge_url(base_url, ids)
+        _make_request.delay(url, method='PURGE_REGEXP')
+
+        logger.debug("purge url:  {}".format(url))
+        logger.info(
+            "purged urls for the 'latest' version of '{}' "
+            "on the legacy domain"
+            .format(', '.join(ids))
+        )
+        # Set up for the next iterative chunk of data
+        start = end

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 # List of known tasks
 TASKS_AS_IMPORT_PATHS = [
-    'press.subscribers.legacy_update_latest.poke_latest',
+    'press.outofband.make_request',
 ]
 
 
@@ -14,7 +14,7 @@ def _make_task(x):
 
 
 @pytest.fixture
-def event_request(pretend_logger):
+def stub_request(pretend_logger):
     # Stub out the Celery app
     tasks = dict(map(_make_task, TASKS_AS_IMPORT_PATHS))
     celery_app = pretend.stub(tasks=tasks)
@@ -35,3 +35,7 @@ def event_request(pretend_logger):
         registry=registry,
     )
     return request
+
+
+# BBB (7-30-12018) to be removed in next commit
+event_request = stub_request

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -35,7 +35,3 @@ def stub_request(pretend_logger):
         registry=registry,
     )
     return request
-
-
-# BBB (7-30-12018) to be removed in next commit
-event_request = stub_request

--- a/tests/unit/subscribers/conftest.py
+++ b/tests/unit/subscribers/conftest.py
@@ -2,16 +2,36 @@ import pretend
 import pytest
 
 
+# List of known tasks
+TASKS_AS_IMPORT_PATHS = [
+    'press.subscribers.legacy_update_latest.poke_latest',
+]
+
+
+def _make_task(x):
+    delay = pretend.call_recorder(lambda *a, **kw: None)
+    return x, pretend.stub(delay=delay)
+
+
 @pytest.fixture
 def event_request(pretend_logger):
-    # Stub out the raven client
+    # Stub out the Celery app
+    tasks = dict(map(_make_task, TASKS_AS_IMPORT_PATHS))
+    celery_app = pretend.stub(tasks=tasks)
+
+    # Stub out the Raven client
     captureException = pretend.call_recorder(lambda: None)
     raven_client = pretend.stub(captureException=captureException)
+
+    # Stub out the Pyramid registry
+    registry = pretend.stub(celery_app=celery_app)
+
     # Create an event with a stub request
     request = pretend.stub(
         domain='example.org',
         scheme='mock',
         log=pretend_logger,
         raven_client=raven_client,
+        registry=registry,
     )
     return request

--- a/tests/unit/subscribers/test_legacy_enqueue.py
+++ b/tests/unit/subscribers/test_legacy_enqueue.py
@@ -1,20 +1,20 @@
 import pretend
-import requests
-import requests_mock as rmock
 
 from press.events import LegacyPublicationFinished
+from press.outofband import make_request
 from press.subscribers.legacy_enqueue import legacy_enqueue
 
-from tests.helpers import (
-    retryable_timeout_request_mock_callback
-)
+
+def _make_url(info):
+    id, ver = info
+    known_base_url = 'mock://legacy.example.org'
+    return (
+        '{}/content/{}/{}/enqueue?colcomplete=True&collxml=True'
+        .format(known_base_url, id, '1.{}'.format(ver[0]))
+    )
 
 
 def test(requests_mock, stub_request):
-    request_callback = pretend.call_recorder(
-        lambda request, context: 'enqueued')
-    # mock the request to enqueue
-    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
 
     # Create an event with a stub request
     ids = [
@@ -27,80 +27,13 @@ def test(requests_mock, stub_request):
     # Call the subcriber
     legacy_enqueue(event)
 
-    # Check for request calls
-    assert len(request_callback.calls) == len(ids)
-    known_base_url = 'mock://legacy.example.org'
-    for i, (id, ver) in enumerate(sorted(ids)):
-        url = (
-            '{}/content/{}/{}/enqueue?colcomplete=True&collxml=True'
-            .format(known_base_url, id, '1.{}'.format(ver[0]))
-        )
-        request, context = request_callback.calls[i].args
-        assert url == request.url
+    # Check for task calls
+    task_path = '.'.join([make_request.__module__, make_request.__name__])
+    task = stub_request.registry.celery_app.tasks[task_path]
+    expected_calls = list(map(pretend.call, map(_make_url, sorted(ids))))
+    assert task.delay.calls == expected_calls
 
     # Check for logging
     assert len(stub_request.log.info.calls) == len(ids)
     for i, (id, ver) in enumerate(sorted(ids)):
         assert id in stub_request.log.info.calls[i].args[0]
-
-
-def test_failed_request_and_retry_failed(requests_mock, stub_request):
-    ids = [
-        ('m12345', (2, None)),
-        ('m54321', (4, None)),
-        ('col32154', (5, 1)),
-    ]
-
-    def request_callback(request, context):
-        if ids[1][0] in request.url:
-            raise requests.exceptions.ConnectTimeout
-        else:
-            return 'enqueued'
-
-    # mock a problem request to enqueue
-    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
-
-    event = LegacyPublicationFinished(ids, stub_request)
-
-    # Call the subcriber
-    legacy_enqueue(event)
-
-    # Check raven was used...
-    assert stub_request.raven_client.captureException.calls
-
-    # Check for logging
-    assert stub_request.log.exception.calls == [
-        pretend.call("problem enqueuing '{}'".format(ids[1][0])),
-    ]
-    assert len(stub_request.log.info.calls) == len(ids) - 1
-    for i, (id, ver) in enumerate(sorted(ids)[:-1]):
-        assert id in stub_request.log.info.calls[i].args[0]
-
-
-def test_failed_request_and_retry_success(requests_mock, stub_request):
-    ids = [
-        ('m12345', (2, None)),
-        ('m54321', (4, None)),
-        ('col32154', (5, 1)),
-    ]
-
-    @retryable_timeout_request_mock_callback
-    def request_callback(request, context, tries):
-        # fails at first but succeeds on the second try
-        if ids[1][0] in request.url and tries < 2:
-            raise requests.exceptions.ConnectTimeout
-        return 'enqueued'
-
-    # mock a problem request to enqueue
-    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
-
-    event = LegacyPublicationFinished(ids, stub_request)
-
-    # Call the subcriber
-    legacy_enqueue(event)
-
-    # Check raven was used...
-    assert stub_request.raven_client.captureException.calls
-
-    # Check for logging
-    assert stub_request.log.exception.calls == []

--- a/tests/unit/subscribers/test_legacy_update_latest.py
+++ b/tests/unit/subscribers/test_legacy_update_latest.py
@@ -1,21 +1,10 @@
 import pretend
-import pytest
-import requests
-import requests_mock as rmock
 
 from press.events import LegacyPublicationFinished
+from press.outofband import make_request
 from press.subscribers.legacy_update_latest import (
-    poke_latest,
     legacy_update_latest,
 )
-
-from tests.helpers import (
-    count_calls,
-)
-
-
-class FauxMaxRetriesExceededError(BaseException):
-    pass
 
 
 class TestLegacyUpdateLatest:
@@ -33,7 +22,7 @@ class TestLegacyUpdateLatest:
         legacy_update_latest(event)
 
         # Check for task calls
-        task_path = '.'.join([poke_latest.__module__, poke_latest.__name__])
+        task_path = '.'.join([make_request.__module__, make_request.__name__])
         task = event_request.registry.celery_app.tasks[task_path]
         expected_calls = [
             pretend.call('mock://legacy.example.org/content/col32154/latest'),
@@ -46,129 +35,3 @@ class TestLegacyUpdateLatest:
         assert len(event_request.log.info.calls) == len(ids)
         for i, (id, ver) in enumerate(sorted(ids)):
             assert id in event_request.log.info.calls[i].args[0]
-
-
-class TestPokeLatest:
-
-    @pytest.fixture(autouse=True)
-    def setup(self, event_request):
-        self.request = event_request
-
-        self.max_retries = 4
-
-        # Mock Celery task
-        @count_calls
-        def retry(exc):
-            if retry.call_count == self.max_retries:
-                raise FauxMaxRetriesExceededError()
-            poke_latest(self.celery_task, self.url)
-
-        self.task_retry_method = pretend.call_recorder(retry)
-        self.celery_task = pretend.stub(
-            get_pyramid_request=lambda: event_request,
-            retry=self.task_retry_method,
-            MaxRetriesExceededError=FauxMaxRetriesExceededError,
-        )
-
-        # Define the parameters
-        self.id = 'm12345'
-        self.url = '{}://legacy.{}/content/{}/latest'.format(
-            self.request.scheme,
-            self.request.domain,
-            self.id,
-        )
-
-    def test_success(self, requests_mock):
-        request_callback = pretend.call_recorder(
-            lambda request, context: 'updated')
-        # Mock the request
-        requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
-
-        # Call the target
-        poke_latest(self.celery_task, self.url)
-
-        # Check for request calls
-        request, context = request_callback.calls[0].args
-        assert request.url == self.url
-
-        # Check for logging
-        assert len(self.request.log.info.calls) == 0
-        assert len(self.request.log.debug.calls) == 0
-        assert len(self.request.log.exception.calls) == 0
-
-    def test_failed_request_and_retry_failed(self, requests_mock):
-
-        @count_calls
-        def request_callback(request, context):
-            if request_callback.call_count < 2:
-                raise requests.exceptions.ConnectTimeout()
-            else:
-                return 'updated'
-
-        # mock a problem request to enqueue
-        requests_mock.register_uri('GET', self.url, text=request_callback)
-
-        # Call the target
-        poke_latest(self.celery_task, self.url)
-
-        # Check that the retry method was called
-        assert len(self.task_retry_method.calls) == 1
-
-        # Make sure the requests_mock callback was called several times
-        assert request_callback.call_count == 2
-
-        # Check raven was used...
-        assert self.request.raven_client.captureException.calls == []
-
-        # Check for logging
-        assert self.request.log.info.calls == []
-        assert self.request.log.debug.calls == []
-        assert self.request.log.exception.calls == [
-            pretend.call("problem fetching '{}'".format(self.url)),
-        ]
-
-    def test_max_retries(self, requests_mock):
-        # Note:
-        #     Because we directly call the target function as part of
-        #     celery task retry, the error cascades through the stack.
-        #     This is not the usual Celery behavior,
-        #     for the sake of testing it works just fine.
-        #     To work around this we'd have to start a valid worker
-        #     subprocess. That's more complicated and error prone.
-
-        @count_calls
-        def request_callback(request, context):
-            raise requests.exceptions.ConnectTimeout()
-
-        # mock a problem request to enqueue
-        requests_mock.register_uri('GET', self.url, text=request_callback)
-
-        # Call the target
-        with pytest.raises(FauxMaxRetriesExceededError):
-            poke_latest(self.celery_task, self.url)
-
-        # Check that the retry method was called
-        assert len(self.task_retry_method.calls) == self.max_retries
-
-        # Make sure the requests_mock callback was called several times
-        assert request_callback.call_count == self.max_retries
-
-        # Check raven was used...
-        expected = [
-            pretend.call(),
-            # See note at the top of this test function.
-            # The following are cascading calls due to the execption rolling
-            # through the stack.
-            pretend.call(),
-            pretend.call(),
-            pretend.call(),
-        ]
-        assert self.request.raven_client.captureException.calls == expected
-
-        # Check for logging
-        assert self.request.log.info.calls == []
-        assert self.request.log.debug.calls == []
-        # See note at the top of this test function.
-        # There should be exception log calls, but because of the nature
-        # of our retry() method, we aren't able to continue through the logic.
-        assert self.request.log.exception.calls == []

--- a/tests/unit/subscribers/test_legacy_update_latest.py
+++ b/tests/unit/subscribers/test_legacy_update_latest.py
@@ -1,105 +1,174 @@
 import pretend
+import pytest
 import requests
 import requests_mock as rmock
 
 from press.events import LegacyPublicationFinished
-from press.subscribers.legacy_update_latest import legacy_update_latest
+from press.subscribers.legacy_update_latest import (
+    poke_latest,
+    legacy_update_latest,
+)
 
 from tests.helpers import (
-    retryable_timeout_request_mock_callback
+    count_calls,
 )
 
 
-def test(requests_mock, event_request):
-    request_callback = pretend.call_recorder(
-        lambda request, context: 'updated')
-    # mock the request to enqueue
-    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
+class FauxMaxRetriesExceededError(BaseException):
+    pass
 
-    # Create an event with a stub request
-    ids = [
-        ('m12345', (2, None)),
-        ('m54321', (4, None)),
-        ('col32154', (5, 1)),
-    ]
-    event = LegacyPublicationFinished(ids, event_request)
 
-    # Call the subcriber
-    legacy_update_latest(event)
+class TestLegacyUpdateLatest:
 
-    # Check for request calls
-    assert len(request_callback.calls) == len(ids)
-    known_base_url = 'mock://legacy.example.org'
-    for i, (id, ver) in enumerate(sorted(ids)):
-        url = (
-            '{}/content/{}/latest'.format(known_base_url, id)
+    def test(self, event_request):
+        # Create an event with a stub request
+        ids = [
+            ('m12345', (2, None)),
+            ('m54321', (4, None)),
+            ('col32154', (5, 1)),
+        ]
+        event = LegacyPublicationFinished(ids, event_request)
+
+        # Call the subcriber
+        legacy_update_latest(event)
+
+        # Check for task calls
+        task_path = '.'.join([poke_latest.__module__, poke_latest.__name__])
+        task = event_request.registry.celery_app.tasks[task_path]
+        expected_calls = [
+            pretend.call('mock://legacy.example.org/content/col32154/latest'),
+            pretend.call('mock://legacy.example.org/content/m12345/latest'),
+            pretend.call('mock://legacy.example.org/content/m54321/latest'),
+        ]
+        assert task.delay.calls == expected_calls
+
+        # Check for logging
+        assert len(event_request.log.info.calls) == len(ids)
+        for i, (id, ver) in enumerate(sorted(ids)):
+            assert id in event_request.log.info.calls[i].args[0]
+
+
+class TestPokeLatest:
+
+    @pytest.fixture(autouse=True)
+    def setup(self, event_request):
+        self.request = event_request
+
+        self.max_retries = 4
+
+        # Mock Celery task
+        @count_calls
+        def retry(exc):
+            if retry.call_count == self.max_retries:
+                raise FauxMaxRetriesExceededError()
+            poke_latest(self.celery_task, self.url)
+
+        self.task_retry_method = pretend.call_recorder(retry)
+        self.celery_task = pretend.stub(
+            get_pyramid_request=lambda: event_request,
+            retry=self.task_retry_method,
+            MaxRetriesExceededError=FauxMaxRetriesExceededError,
         )
-        request, context = request_callback.calls[i].args
-        assert url == request.url
 
-    # Check for logging
-    assert len(event_request.log.info.calls) == len(ids)
-    for i, (id, ver) in enumerate(sorted(ids)):
-        assert id in event_request.log.info.calls[i].args[0]
+        # Define the parameters
+        self.id = 'm12345'
+        self.url = '{}://legacy.{}/content/{}/latest'.format(
+            self.request.scheme,
+            self.request.domain,
+            self.id,
+        )
 
+    def test_success(self, requests_mock):
+        request_callback = pretend.call_recorder(
+            lambda request, context: 'updated')
+        # Mock the request
+        requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
 
-def test_failed_request_and_retry_failed(requests_mock, event_request):
-    ids = [
-        ('m12345', (2, None)),
-        ('m54321', (4, None)),
-        ('col32154', (5, 1)),
-    ]
+        # Call the target
+        poke_latest(self.celery_task, self.url)
 
-    def request_callback(request, context):
-        if ids[1][0] in request.url:
-            raise requests.exceptions.ConnectTimeout
-        else:
-            return 'updated'
+        # Check for request calls
+        request, context = request_callback.calls[0].args
+        assert request.url == self.url
 
-    # mock a problem request to enqueue
-    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
+        # Check for logging
+        assert len(self.request.log.info.calls) == 0
+        assert len(self.request.log.debug.calls) == 0
+        assert len(self.request.log.exception.calls) == 0
 
-    event = LegacyPublicationFinished(ids, event_request)
+    def test_failed_request_and_retry_failed(self, requests_mock):
 
-    # Call the subcriber
-    legacy_update_latest(event)
+        @count_calls
+        def request_callback(request, context):
+            if request_callback.call_count < 2:
+                raise requests.exceptions.ConnectTimeout()
+            else:
+                return 'updated'
 
-    # Check raven was used...
-    assert event_request.raven_client.captureException.calls
+        # mock a problem request to enqueue
+        requests_mock.register_uri('GET', self.url, text=request_callback)
 
-    # Check for logging
-    assert event_request.log.exception.calls == [
-        pretend.call("problem fetching '{}'".format(ids[1][0])),
-    ]
-    assert len(event_request.log.info.calls) == len(ids) - 1
-    for i, (id, ver) in enumerate(sorted(ids)[:-1]):
-        assert id in event_request.log.info.calls[i].args[0]
+        # Call the target
+        poke_latest(self.celery_task, self.url)
 
+        # Check that the retry method was called
+        assert len(self.task_retry_method.calls) == 1
 
-def test_failed_request_and_retry_success(requests_mock, event_request):
-    ids = [
-        ('m12345', (2, None)),
-        ('m54321', (4, None)),
-        ('col32154', (5, 1)),
-    ]
+        # Make sure the requests_mock callback was called several times
+        assert request_callback.call_count == 2
 
-    @retryable_timeout_request_mock_callback
-    def request_callback(request, context, tries):
-        # fails at first but succeeds on the second try
-        if ids[1][0] in request.url and tries < 2:
-            raise requests.exceptions.ConnectTimeout
-        return 'updated'
+        # Check raven was used...
+        assert self.request.raven_client.captureException.calls == []
 
-    # mock a problem request to enqueue
-    requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
+        # Check for logging
+        assert self.request.log.info.calls == []
+        assert self.request.log.debug.calls == []
+        assert self.request.log.exception.calls == [
+            pretend.call("problem fetching '{}'".format(self.url)),
+        ]
 
-    event = LegacyPublicationFinished(ids, event_request)
+    def test_max_retries(self, requests_mock):
+        # Note:
+        #     Because we directly call the target function as part of
+        #     celery task retry, the error cascades through the stack.
+        #     This is not the usual Celery behavior,
+        #     for the sake of testing it works just fine.
+        #     To work around this we'd have to start a valid worker
+        #     subprocess. That's more complicated and error prone.
 
-    # Call the subcriber
-    legacy_update_latest(event)
+        @count_calls
+        def request_callback(request, context):
+            raise requests.exceptions.ConnectTimeout()
 
-    # Check raven was used...
-    assert event_request.raven_client.captureException.calls
+        # mock a problem request to enqueue
+        requests_mock.register_uri('GET', self.url, text=request_callback)
 
-    # Check for logging
-    assert event_request.log.exception.calls == []
+        # Call the target
+        with pytest.raises(FauxMaxRetriesExceededError):
+            poke_latest(self.celery_task, self.url)
+
+        # Check that the retry method was called
+        assert len(self.task_retry_method.calls) == self.max_retries
+
+        # Make sure the requests_mock callback was called several times
+        assert request_callback.call_count == self.max_retries
+
+        # Check raven was used...
+        expected = [
+            pretend.call(),
+            # See note at the top of this test function.
+            # The following are cascading calls due to the execption rolling
+            # through the stack.
+            pretend.call(),
+            pretend.call(),
+            pretend.call(),
+        ]
+        assert self.request.raven_client.captureException.calls == expected
+
+        # Check for logging
+        assert self.request.log.info.calls == []
+        assert self.request.log.debug.calls == []
+        # See note at the top of this test function.
+        # There should be exception log calls, but because of the nature
+        # of our retry() method, we aren't able to continue through the logic.
+        assert self.request.log.exception.calls == []

--- a/tests/unit/subscribers/test_legacy_update_latest.py
+++ b/tests/unit/subscribers/test_legacy_update_latest.py
@@ -9,21 +9,21 @@ from press.subscribers.legacy_update_latest import (
 
 class TestLegacyUpdateLatest:
 
-    def test(self, event_request):
+    def test(self, stub_request):
         # Create an event with a stub request
         ids = [
             ('m12345', (2, None)),
             ('m54321', (4, None)),
             ('col32154', (5, 1)),
         ]
-        event = LegacyPublicationFinished(ids, event_request)
+        event = LegacyPublicationFinished(ids, stub_request)
 
         # Call the subcriber
         legacy_update_latest(event)
 
         # Check for task calls
         task_path = '.'.join([make_request.__module__, make_request.__name__])
-        task = event_request.registry.celery_app.tasks[task_path]
+        task = stub_request.registry.celery_app.tasks[task_path]
         expected_calls = [
             pretend.call('mock://legacy.example.org/content/col32154/latest'),
             pretend.call('mock://legacy.example.org/content/m12345/latest'),
@@ -32,6 +32,6 @@ class TestLegacyUpdateLatest:
         assert task.delay.calls == expected_calls
 
         # Check for logging
-        assert len(event_request.log.info.calls) == len(ids)
+        assert len(stub_request.log.info.calls) == len(ids)
         for i, (id, ver) in enumerate(sorted(ids)):
-            assert id in event_request.log.info.calls[i].args[0]
+            assert id in stub_request.log.info.calls[i].args[0]

--- a/tests/unit/test_outofband.py
+++ b/tests/unit/test_outofband.py
@@ -1,0 +1,144 @@
+import pretend
+import pytest
+import requests
+import requests_mock as rmock
+
+from press.outofband import make_request
+
+from tests.helpers import (
+    count_calls,
+)
+
+
+class FauxMaxRetriesExceededError(BaseException):
+    pass
+
+
+class TestMakeRequest:
+
+    @property
+    def target(self):
+        return make_request
+
+    @pytest.fixture(autouse=True)
+    def setup(self, stub_request):
+        self.request = stub_request
+
+        self.max_retries = 4
+
+        # Mock Celery task
+        @count_calls
+        def retry(exc):
+            if retry.call_count == self.max_retries:
+                raise FauxMaxRetriesExceededError()
+            self.target(self.celery_task, self.url)
+
+        self.task_retry_method = pretend.call_recorder(retry)
+        self.celery_task = pretend.stub(
+            get_pyramid_request=lambda: self.request,
+            retry=self.task_retry_method,
+            MaxRetriesExceededError=FauxMaxRetriesExceededError,
+        )
+
+        # Define the parameters
+        self.id = 'm12345'
+        self.url = '{}://legacy.{}/content/{}/latest'.format(
+            self.request.scheme,
+            self.request.domain,
+            self.id,
+        )
+
+    def test_success(self, requests_mock):
+        request_callback = pretend.call_recorder(
+            lambda request, context: 'updated')
+        # Mock the request
+        requests_mock.register_uri('GET', rmock.ANY, text=request_callback)
+
+        # Call the target
+        self.target(self.celery_task, self.url)
+
+        # Check for request calls
+        request, context = request_callback.calls[0].args
+        assert request.url == self.url
+
+        # Check for logging
+        assert len(self.request.log.info.calls) == 0
+        assert len(self.request.log.debug.calls) == 0
+        assert len(self.request.log.exception.calls) == 0
+
+    def test_failed_request_and_retry(self, requests_mock):
+
+        @count_calls
+        def request_callback(request, context):
+            if request_callback.call_count < 2:
+                raise requests.exceptions.ConnectTimeout()
+            else:
+                return 'updated'
+
+        # mock a problem request to enqueue
+        requests_mock.register_uri('GET', self.url, text=request_callback)
+
+        # Call the target
+        self.target(self.celery_task, self.url)
+
+        # Check that the retry method was called
+        assert len(self.task_retry_method.calls) == 1
+
+        # Make sure the requests_mock callback was called several times
+        assert request_callback.call_count == 2
+
+        # Check raven was used...
+        assert self.request.raven_client.captureException.calls == []
+
+        # Check for logging
+        assert self.request.log.info.calls == []
+        assert self.request.log.debug.calls == []
+        assert self.request.log.exception.calls == [
+            pretend.call("problem requesting '{}'".format(self.url)),
+        ]
+
+    def test_max_retries(self, requests_mock):
+        # Note:
+        #     Because we directly call the target function as part of
+        #     celery task retry, the error cascades through the stack.
+        #     This is not the usual Celery behavior,
+        #     for the sake of testing it works just fine.
+        #     To work around this we'd have to start a valid worker
+        #     subprocess. That's more complicated and error prone.
+
+        @count_calls
+        def request_callback(request, context):
+            raise requests.exceptions.ConnectTimeout()
+
+        # mock a problem request to enqueue
+        requests_mock.register_uri('GET', self.url, text=request_callback)
+
+        # Call the target
+        with pytest.raises(FauxMaxRetriesExceededError):
+            self.target(self.celery_task, self.url)
+
+        # Check that the retry method was called
+        assert len(self.task_retry_method.calls) == self.max_retries
+
+        # Make sure the requests_mock callback was called several times
+        assert request_callback.call_count == self.max_retries
+
+        # Check raven was used...
+        expected = [
+            pretend.call(),
+            # See note at the top of this test function.
+            # The following are cascading calls due to the execption rolling
+            # through the stack.
+            pretend.call(),
+            pretend.call(),
+            pretend.call(),
+        ]
+        assert self.request.raven_client.captureException.calls == expected
+
+        # Check for logging
+        assert self.request.log.info.calls == []
+        assert self.request.log.debug.calls == []
+        # See note at the top of this test function.
+        # There should be exception log calls, but because of the nature
+        # of our retry() method, we aren't able to continue through the logic.
+        assert self.request.log.exception.calls == []

--- a/tests/unit/test_outofband.py
+++ b/tests/unit/test_outofband.py
@@ -66,6 +66,30 @@ class TestMakeRequest:
         assert len(self.request.log.debug.calls) == 0
         assert len(self.request.log.exception.calls) == 0
 
+    def test_custom_request_method(self, requests_mock):
+        request_callback = pretend.call_recorder(
+            lambda request, context: 'ok')
+        # Mock the request
+        request_method = 'KISS'
+        requests_mock.register_uri(
+            request_method,
+            rmock.ANY,
+            text=request_callback,
+        )
+
+        # Call the target
+        self.target(self.celery_task, self.url, method=request_method)
+
+        # Check for request calls
+        request, context = request_callback.calls[0].args
+        assert request.url == self.url
+        assert request.method == request_method
+
+        # Check for logging
+        assert len(self.request.log.info.calls) == 0
+        assert len(self.request.log.debug.calls) == 0
+        assert len(self.request.log.exception.calls) == 0
+
     def test_failed_request_and_retry(self, requests_mock):
 
         @count_calls


### PR DESCRIPTION
Basically this adjusts all the event subscribers that have HTTP requests to make those HTTP requests as Celery tasks.

We also are taking advantage of using Celery's retry behavior rather than retrying the requests with custom cascading code.

This should correct the latency issues related to waiting for these requests to go through. Addresses #114 

This may not be 100% complete, but it is a step in the right direction. I'm speculating we'll need to add a few lines of configuration for detailing which queue to use, so we don't conflict with the cnx-publishing queues.