### PR TITLE
Prevent overwrite

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+?.?.?
+-----
+
+- Add functionality to stop accidently overwriting others published changes
+
 4.0.0
 -----
 

--- a/press/errors.py
+++ b/press/errors.py
@@ -1,0 +1,6 @@
+class StaleVersion(Exception):
+    """Raised when checked out version is older than published version"""
+    def __init__(self, checked_out_version, current_version, item):
+        self.checked_out_version = checked_out_version
+        self.current_version = current_version
+        self.item = item

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -2,7 +2,7 @@ from pyramid.threadlocal import get_current_request
 from sqlalchemy.sql import text
 
 from .utils import replace_id_and_version
-
+from ..errors import StaleVersion
 
 __all__ = (
     'publish_legacy_page',
@@ -34,6 +34,10 @@ def publish_legacy_page(model, metadata, submission, db_conn):
     )
     # At this time, this code assumes an existing module
     existing_module = result.fetchone()
+
+    if metadata.version != existing_module.version:
+        raise StaleVersion(metadata.version, existing_module.version, model)
+
     major_version = existing_module.major_version + 1
 
     # Get existing abstract, if exists, otherwise add it


### PR DESCRIPTION
Adds a custom error "StaleVersion" which is thrown when the version of the object being published is not equal to the version currently in the database, to avoid "last to publish wins" race conditions.

Includes tests for both a module an a collection-only overwrite.