### PR TITLE
Pin all versions of dependent packages

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,2 +1,3 @@
 # The project's deployment dependencies...
+
 gunicorn==19.8.1

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,20 +1,85 @@
 # The project's dependencies...
+
+amqp==2.3.2
+
+billiard==3.5.0.4
+
+bravado-core==5.0.5
+
 celery==4.2.1
+
+certifi==2018.4.16
+
+chardet==3.0.4
 
 # If this pinning changes, remember to also change the pinning of the
 # cnx-db docker container image.
 cnx-db==2.2.1
 
+cnx-litezip==1.3.1
+
 cnxml==2.1.1
 
-cnx-litezip==1.3.1
+hupper==1.3
+
+idna==2.7
+
+jsonref==0.1
+
+jsonschema==2.6.0
+
+kombu==4.2.1
+
+lxml==4.2.4
+
+msgpack-python==0.5.6
+
+PasteDeploy==1.5.2
+
+plaster==1.0
+
+plaster-pastedeploy==0.6
+
+psycopg2==2.7.5
 
 pyramid==1.9.2
 
-pyramid_swagger==2.6.2
+pyramid-swagger==2.6.2
+
+python-dateutil==2.7.3
+
+pytz==2018.5
+
+PyYAML==3.13
 
 raven==6.9.0
 
+repoze.lru==0.7
+
 requests==2.19.1
 
+rhaptos.cnxmlutils==1.3.2
+
+simplejson==3.16.0
+
+six==1.11.0
+
+SQLAlchemy==1.2.10
+
 structlog==18.1.0
+
+swagger-spec-validator==2.3.1
+
+translationstring==1.3
+
+urllib3==1.23
+
+venusian==1.1.0
+
+vine==1.1.4
+
+WebOb==1.8.2
+
+zope.deprecation==4.3.0
+
+zope.interface==4.5.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,9 +1,31 @@
 # The project's testing dependencies...
 -r ./main.txt
 
-jinja2==2.10
+atomicwrites==1.1.5
+
+attrs==18.1.0
+
+beautifulsoup4==4.6.1
+
+certifi==2018.4.16
+
+chardet==3.0.4
+
+coverage==4.5.1
+
+idna==2.7
+
+Jinja2==2.10
+
+MarkupSafe==1.0
+
+more-itertools==4.3.0
+
+pluggy==0.7.1
 
 pretend==1.0.9
+
+py==1.5.4
 
 pytest==3.7.0
 
@@ -13,6 +35,16 @@ python-dateutil==2.7.3
 
 recordclass==0.5
 
+requests==2.19.1
+
 requests-mock==1.5.2
 
-WebTest >= 1.3.1
+six==1.11.0
+
+urllib3==1.23
+
+waitress==1.1.0
+
+WebOb==1.8.2
+
+WebTest==2.0.30


### PR DESCRIPTION
This will allow pyup.io to track changes to any dependencies.
We track those changes here because the app has the authority over it's
dependencies. It also more importantly has the ability exercise the
fitness and feasiblity of upgrading those dependencies through the test suite.

We'll need a way to keep this up-to-date as dependencies get added,
but that will be work for another changeset.