### PR TITLE
Use the existing record's 'created' value

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -2,6 +2,13 @@
 Change Log
 ==========
 
+4.1.1
+-----
+
+- Fix publish submission logic to use the existing 'created' value
+  rather than reading it from the xml document's metadata.
+  See https://github.com/Connexions/cnx-press/issues/148
+
 4.1.0
 -----
 

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -70,7 +70,7 @@ def publish_legacy_book(model, metadata, submission, db_conn):
         major_version=major_version,
         portal_type='Collection',
         name=metadata.title,
-        created=metadata.created,
+        created=existing_module.created,
         abstractid=abstractid,
         licenseid=licenseid,
         doctype='',

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -65,7 +65,7 @@ def publish_legacy_page(model, metadata, submission, db_conn):
         major_version=major_version,
         portal_type='Module',
         name=metadata.title,
-        created=metadata.created,
+        created=existing_module.created,
         abstractid=abstractid,
         licenseid=licenseid,
         doctype='',


### PR DESCRIPTION
Fix publish submission logic to use the existing 'created' value rather than reading it from the xml document's metadata.

Addresses #148 