### PR TITLE
Add a Jenkinsfile for releasing the Docker image

### DIFF
--- a/.jenkins/deploy
+++ b/.jenkins/deploy
@@ -1,0 +1,34 @@
+pipeline {
+  agent { label 'docker' }
+  stages {
+    stage('Build') {
+      steps {
+        sh "docker build -t openstax/cnx-press:dev ."
+      }
+    }
+    stage('Publish Dev Container') {
+      steps {
+        // 'docker-registry' is defined in Jenkins under credentials
+        withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
+          sh "docker push openstax/cnx-press:dev"
+        }
+      }
+    }
+    stage('Publish Release') {
+      when {
+        expression {
+          release = sh(returnStdout: true, script: 'git tag -l --points-at HEAD | head -n 1').trim()
+          return release
+        }
+      }
+      steps {
+        withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
+          sh "docker tag openstax/cnx-press:dev openstax/cnx-press:${release}"
+          sh "docker tag openstax/cnx-press:dev openstax/cnx-press:latest"
+          sh "docker push openstax/cnx-press:${release}"
+          sh "docker push openstax/cnx-press:latest"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a copy and paste operation that works of @TomWoodward's deployment Jenkinsfile. I've dropped the deployment part for now. This will at least enable us to release the image on merge to master.