### PR TITLE
save unicode/utf8 xml

### DIFF
--- a/press/legacy_publishing/litezip.py
+++ b/press/legacy_publishing/litezip.py
@@ -57,7 +57,7 @@ def publish_litezip(struct, submission, db_conn):
 
     # Rebuild the Collection tree from the newly published Modules.
     with collection.file.open('wb') as fb:
-        fb.write(etree.tostring(xml))
+        fb.write(etree.tounicode(xml).encode('utf8'))
 
     # Publish the Collection.
     metadata = parse_collection_metadata(collection)

--- a/press/legacy_publishing/utils.py
+++ b/press/legacy_publishing/utils.py
@@ -60,7 +60,7 @@ def replace_derived_from(model, derived_from_url):
         metadata_elm.append(derived_from_elm)
 
     with model.file.open('wb') as fb:
-        fb.write(etree.tostring(xml))
+        fb.write(etree.tounicode(xml).encode('utf8'))
 
 
 def replace_id_and_version(model, id, version):
@@ -82,4 +82,4 @@ def replace_id_and_version(model, id, version):
     elm = xml.xpath('//md:version', namespaces=COLLECTION_NSMAP)[0]
     elm.text = convert_version_to_legacy_version(version)
     with model.file.open('wb') as fb:
-        fb.write(etree.tostring(xml))
+        fb.write(etree.tounicode(xml).encode('utf8'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -870,7 +870,7 @@ class _PersistUtil:
             elm = xml.xpath('//md:content-id', namespaces=COLLECTION_NSMAP)[0]
             elm.text = id
             with model.file.open('wb') as fb:
-                fb.write(etree.tostring(xml))
+                fb.write(etree.tounicode(xml).encode('utf8'))
 
             # Insert content files
             with model.file.open('rb') as fb:
@@ -921,7 +921,7 @@ class _PersistUtil:
             elm = xml.xpath('//md:content-id', namespaces=COLLECTION_NSMAP)[0]
             elm.text = id
             with model.file.open('wb') as fb:
-                fb.write(etree.tostring(xml))
+                fb.write(etree.tounicode(xml).encode('utf8'))
 
             # Insert content files
             with model.file.open('rb') as fb:

--- a/tests/functional/views/test_legacy_publishing.py
+++ b/tests/functional/views/test_legacy_publishing.py
@@ -95,7 +95,7 @@ def test_publishing_invalid_revision_litezip(content_util, persist_util,
                 nsmap=COLLECTION_NSMAP))
     with collection.file.open('wb') as fb:
         # Write the modified xml back to file.
-        fb.write(etree.tostring(xml))
+        fb.write(etree.tounicode(xml).encode('utf8'))
     # Modify the module content to make it invalid.
     with new_module.file.open('rb') as fb:
         xml = etree.parse(fb)
@@ -118,7 +118,7 @@ def test_publishing_invalid_revision_litezip(content_util, persist_util,
                 nsmap=COLLECTION_NSMAP))
     with new_module.file.open('wb') as fb:
         # Write the modified xml back to file.
-        fb.write(etree.tostring(xml))
+        fb.write(etree.tounicode(xml).encode('utf8'))
 
     # Compress to zip file as payload
     file = content_util.mk_zipfile_from_litezip_struct(struct)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,7 +36,7 @@ def element_tree_from_model(model):
     yield xml
 
     with model.file.open('wb') as fb:
-        fb.write(etree.tostring(xml))
+        fb.write(etree.tounicode(xml).encode('utf8'))
 
 
 def compare_legacy_tree_similarity(db_tree, test_tree):

--- a/tests/unit/parsers/test_collection.py
+++ b/tests/unit/parsers/test_collection.py
@@ -61,7 +61,7 @@ def test_parse_colletion_metdata_without_print_style(tmpdir,
         elm = xml.xpath('//col:param[@name="print-style"]',
                         namespaces=COLLECTION_NSMAP)[0]
         elm.getparent().remove(elm)
-        collection_file.write(etree.tostring(xml))
+        collection_file.write(etree.tounicode(xml).encode('utf8'))
     assert 'print-style' not in collection_file.read()
 
     # Test the parser doesn't error when a print-style is missing.
@@ -84,7 +84,7 @@ def test_parse_colletion_metdata_with_print_style(tmpdir,
         elm = xml.xpath('//col:param[@name="print-style"]',
                         namespaces=COLLECTION_NSMAP)[0]
         elm.attrib['value'] = specific_print_style
-        collection_file.write(etree.tostring(xml))
+        collection_file.write(etree.tounicode(xml).encode('utf8'))
 
     # Test the parser doesn't error when a print-style is missing.
     # given a Collection object,


### PR DESCRIPTION
this avoids the ASCII XML ampersand escaping, so the content managers can edit in UTF8