### PR TITLE
Remove attrs library from requirements for testing

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,8 +3,6 @@
 
 atomicwrites==1.1.5
 
-attrs==18.1.0
-
 beautifulsoup4==4.6.3
 
 certifi==2018.8.13


### PR DESCRIPTION
`attrs` library isn't being used anywhere in the code anymore.

Found this while merging PRs created by pyup bot (for reference: https://github.com/Connexions/cnx-press/pull/188).