### PR TITLE
Rename alias base64 decoder to rm warning

### DIFF
--- a/press/auth.py
+++ b/press/auth.py
@@ -1,5 +1,5 @@
 import hashlib
-from base64 import decodestring as decode
+from base64 import decodebytes as decode
 from pyramid.authentication import BasicAuthAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.security import Allow, Authenticated


### PR DESCRIPTION
After merging _some_ PRs  by pybot to upgrade some libraries, a warning is raised by every single test. This is because Python's `base64` library renamed `decodestring` to `decodebytes`. This PR gets rid of the warning.