### PR TITLE
Remove atomicwrites lib from testing dependencies

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,8 +1,6 @@
 # The project's testing dependencies...
 -r ./main.txt
 
-atomicwrites==1.1.5
-
 attrs==18.1.0
 
 beautifulsoup4==4.6.3


### PR DESCRIPTION
This is no longer being used. This PR removes the dependency in tests. Found while merging pyup bot PRs (https://github.com/Connexions/cnx-press/pull/175).