### PR TITLE
to be consistent w/ other repos ignore W504

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 exclude = *.egg,.state
 select = E,W,F,N
+ignore = W504
 
 [doc8]
 ignore-path = docs/build/


### PR DESCRIPTION
press currently doesn't need this (no line breaks on binary operators) but to stay consistent w/ the other repos, adding it here.