### PR TITLE
Enforce: changes to collection.xml are not allowed (temporary policy)

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -7,6 +7,11 @@ Change Log
 - Dry out ping API and add swagger docs
 
 
+7.2.0
+-----
+- Prevent any changes to collection.xml files
+- Only publish changed modules
+
 7.1.0
 -----
 

--- a/press/errors.py
+++ b/press/errors.py
@@ -10,3 +10,9 @@ class Unchanged(Exception):
     """Raised when checked out version is older than published version"""
     def __init__(self, model):
         self.model = model
+
+
+class CollectionChanged(Exception):
+    """Raised when checked out version is older than published version"""
+    def __init__(self, collection):
+        self.collection = collection

--- a/press/errors.py
+++ b/press/errors.py
@@ -4,3 +4,9 @@ class StaleVersion(Exception):
         self.checked_out_version = checked_out_version
         self.current_version = current_version
         self.item = item
+
+
+class Unchanged(Exception):
+    """Raised when checked out version is older than published version"""
+    def __init__(self, model):
+        self.model = model

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -56,7 +56,8 @@ def publish_legacy_book(model, metadata, submission, db_conn, changed=None):
     existing_shas = {filename: sha for filename, sha in shas}
 
     # if the collection changed at all
-    if existing_shas.get('collection.xml') != produce_hashes_from_filepath(model.file)['sha1']:
+    existing_sha1 = existing_shas.get('collection.xml')
+    if existing_sha1 != produce_hashes_from_filepath(model.file)['sha1']:
         raise CollectionChanged(model)
     # OR if any of its resources changed
     for res in model.resources:

--- a/press/legacy_publishing/collection.py
+++ b/press/legacy_publishing/collection.py
@@ -30,10 +30,10 @@ def publish_legacy_book(model, metadata, submission, db_conn, changed=None):
         raise NotImplementedError()
 
     result = db_conn.execute(
-        t.latest_modules.select()
-        .where(t.latest_modules.c.moduleid == metadata.id)
-        .order_by(t.latest_modules.c.major_version.desc(),
-                  t.latest_modules.c.minor_version.desc())
+        t.modules.select()
+        .where(t.modules.c.moduleid == metadata.id)
+        .order_by(t.modules.c.major_version.desc(),
+                  t.modules.c.minor_version.desc())
         .limit(1))
     # At this time, this code assumes an existing module
     existing_module = result.fetchone()

--- a/press/legacy_publishing/litezip.py
+++ b/press/legacy_publishing/litezip.py
@@ -4,7 +4,6 @@ from lxml import etree
 from litezip import Collection, Module
 
 from press.parsers import parse_collection_metadata, parse_module_metadata
-from press.errors import CollectionChanged
 
 from .collection import publish_legacy_book
 from .module import publish_legacy_page
@@ -40,9 +39,9 @@ def publish_litezip(struct, submission, db_conn, coll_changes_allowed=True):
         metadata = parse_module_metadata(module)
         publish_legacy_book(collection, metadata, submission, db_conn)
     except IndexError:  # pragma: no cover
-        pass # if no modules, no problem.
+        pass  # if no modules, no problem.
 
-    id_map = {}
+    id_map = {}  # pragma: no cover
 
     # Parse Collection tree to update the newly published Modules.
     with collection.file.open('rb') as fb:

--- a/press/legacy_publishing/litezip.py
+++ b/press/legacy_publishing/litezip.py
@@ -60,8 +60,8 @@ def publish_litezip(struct, submission, db_conn):
         except Unchanged:
             pass
 
-    changed = id_map != {}
-    if changed:
+    did_change = id_map != {}
+    if did_change:
         # Rebuild the Collection tree from the newly published Modules.
         with collection.file.open('wb') as fb:
             fb.write(etree.tounicode(xml).encode('utf8'))
@@ -69,8 +69,8 @@ def publish_litezip(struct, submission, db_conn):
     # Maybe publish the Collection.
     metadata = parse_collection_metadata(collection)
     old_id = collection.id
-    (id, version), ident = publish_legacy_book(collection, metadata,
-                                               submission, db_conn, changed)
+    (id, version), ident = publish_legacy_book(
+        collection, metadata, submission, db_conn, changed=did_change)
     id_map[old_id] = (id, version)
 
     return id_map

--- a/press/legacy_publishing/litezip.py
+++ b/press/legacy_publishing/litezip.py
@@ -68,8 +68,8 @@ def publish_litezip(struct, submission, db_conn, coll_changes_allowed=True):
         except Unchanged:
             pass
 
-    did_change = id_map != {}
-    if did_change:
+    any_changes = id_map != {}
+    if any_changes:
         # Rebuild the Collection tree from the newly published Modules.
         with collection.file.open('wb') as fb:
             fb.write(etree.tounicode(xml).encode('utf8'))
@@ -78,7 +78,7 @@ def publish_litezip(struct, submission, db_conn, coll_changes_allowed=True):
     metadata = parse_collection_metadata(collection)
     old_id = collection.id
     (id, version), ident = publish_legacy_book(
-        collection, metadata, submission, db_conn, changed=did_change)
+        collection, metadata, submission, db_conn, changed=any_changes)
     id_map[old_id] = (id, version)
 
     return id_map

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -48,8 +48,8 @@ def publish_legacy_page(model, metadata, submission, db_conn):
 
     existing_shas = {filename: sha for filename, sha in shas}
 
-    sha1 = produce_hashes_from_filepath(model.file)['sha1']
-    if sha1 == existing_shas['index.cnxml']:
+    mod_sha1 = produce_hashes_from_filepath(model.file)['sha1']
+    if mod_sha1 == existing_shas['index.cnxml']:
         for res in model.resources:
             if res.sha1 != existing_shas[res.filename]:
                 break  # publish!

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -1,8 +1,8 @@
 from pyramid.threadlocal import get_current_request
 from sqlalchemy.sql import text
 
-from .utils import replace_id_and_version
-from ..errors import StaleVersion
+from .utils import replace_id_and_version, produce_hashes_from_filepath
+from ..errors import StaleVersion, Unchanged
 
 __all__ = (
     'publish_legacy_page',
@@ -32,11 +32,29 @@ def publish_legacy_page(model, metadata, submission, db_conn):
         t.latest_modules.select()
         .where(t.latest_modules.c.moduleid == metadata.id)
     )
+
     # At this time, this code assumes an existing module
     existing_module = result.fetchone()
 
     if metadata.version != existing_module.version:
         raise StaleVersion(metadata.version, existing_module.version, model)
+
+    shas = (db_conn.execute(
+            text("SELECT filename, sha1 FROM module_files"
+                 " JOIN files USING (fileid)"
+                 " WHERE module_ident = :mod_ident")
+            .bindparams(mod_ident=existing_module.module_ident))
+            ).fetchall()
+
+    existing_shas = {filename: sha for filename, sha in shas}
+
+    sha1 = produce_hashes_from_filepath(model.file)['sha1']
+    if sha1 == existing_shas['index.cnxml']:
+        for res in model.resources:
+            if res.sha1 != existing_shas[res.filename]:
+                break  # publish!
+        else:  # cnxml and all resources are identical to already published
+            raise Unchanged(model)
 
     major_version = existing_module.major_version + 1
 

--- a/press/legacy_publishing/module.py
+++ b/press/legacy_publishing/module.py
@@ -51,7 +51,8 @@ def publish_legacy_page(model, metadata, submission, db_conn):
     mod_sha1 = produce_hashes_from_filepath(model.file)['sha1']
     if mod_sha1 == existing_shas['index.cnxml']:
         for res in model.resources:
-            if res.sha1 != existing_shas[res.filename]:
+            if (res.filename not in existing_shas or
+                    res.sha1 != existing_shas[res.filename]):
                 break  # publish!
         else:  # cnxml and all resources are identical to already published
             raise Unchanged(model)

--- a/press/legacy_publishing/utils.py
+++ b/press/legacy_publishing/utils.py
@@ -5,12 +5,14 @@ from litezip import (
 from litezip.main import COLLECTION_NSMAP
 from lxml import etree
 
-from ..utils import convert_version_to_legacy_version
+from ..utils import convert_version_to_legacy_version, \
+    produce_hashes_from_filepath
 
 
 __all__ = (
     'replace_derived_from',
     'replace_id_and_version',
+    'produce_hashes_from_filepath',
 )
 
 

--- a/press/views/api-docs/swagger.yaml
+++ b/press/views/api-docs/swagger.yaml
@@ -743,12 +743,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/Publication'
-        '401':
-          description: requires permission to publish
-          schema:
-            $ref: '#/definitions/PublicationError'
+        '202':
+          description: Nothing to publish
         '400':
           description: error during publication
+          schema:
+            $ref: '#/definitions/PublicationError'
+        '401':
+          description: requires permission to publish
           schema:
             $ref: '#/definitions/PublicationError'
       consumes:

--- a/press/views/legacy_publishing.py
+++ b/press/views/legacy_publishing.py
@@ -85,15 +85,8 @@ def publish(request):
              }
         ]}
     except Unchanged:
-        request.response.status = 204  # maybe?  # TODO: change neb as well.
-        return {'messages': [  # nothing to publish
-            {'id': 4,
-             'message': 'nothing to publish',
-             'item': 'TODO',  # TODO: FIX ME
-             'error': 'None of the models changed, '
-                      'there is nothing to publish.'
-             }
-        ]}
+        request.response.status = 202  # maybe?  # TODO: change neb as well.
+        return None
 
     finish_event = events.LegacyPublicationFinished(
         id_mapping.values(),

--- a/press/views/legacy_publishing.py
+++ b/press/views/legacy_publishing.py
@@ -5,7 +5,7 @@ from litezip import parse_litezip, validate_litezip
 from pyramid.view import view_config
 
 from .. import events
-from ..errors import StaleVersion
+from ..errors import StaleVersion, Unchanged
 from ..legacy_publishing import publish_litezip
 from ..publishing import (
     discover_content_dir,
@@ -82,6 +82,16 @@ def publish(request):
                       ' but currently published'
                       ' is {cv}'.format(co=err.checked_out_version,
                                         cv=err.current_version),
+             }
+        ]}
+    except Unchanged:
+        request.response.status = 204  # maybe?  # TODO: change neb as well.
+        return {'messages': [  # nothing to publish
+            {'id': 4,
+             'message': 'nothing to publish',
+             'item': 'TODO',  # TODO: FIX ME
+             'error': 'None of the models changed, '
+                      'there is nothing to publish.'
              }
         ]}
 

--- a/press/views/legacy_publishing.py
+++ b/press/views/legacy_publishing.py
@@ -71,7 +71,7 @@ def publish(request):
     try:
         with request.get_db_engine('common').begin() as db_conn:
             id_mapping = publish_litezip(litezip_struct, (publisher, message),
-                                         db_conn, coll_changes_allowed=False)
+                                         db_conn)
     except StaleVersion as err:
         request.response.status = 400
         return {'messages': [

--- a/tests/functional/legacy_publishing/test_litezip.py
+++ b/tests/functional/legacy_publishing/test_litezip.py
@@ -1,12 +1,6 @@
-from sqlalchemy.sql import text
-
 from press.errors import CollectionChanged
 from press.legacy_publishing.litezip import (
     publish_litezip,
-)
-
-from tests.helpers import (
-    compare_legacy_tree_similarity,
 )
 
 
@@ -32,7 +26,7 @@ def test_publish_litezip(
 
     try:
         with db_engines['common'].begin() as conn:
-            id_map = publish_litezip(
+            publish_litezip(
                 struct,
                 ('user1', 'test publish',),
                 conn,

--- a/tests/functional/legacy_publishing/test_litezip.py
+++ b/tests/functional/legacy_publishing/test_litezip.py
@@ -1,5 +1,6 @@
 from sqlalchemy.sql import text
 
+from press.errors import CollectionChanged
 from press.legacy_publishing.litezip import (
     publish_litezip,
 )
@@ -29,6 +30,17 @@ def test_publish_litezip(
                                                                 tree)
     struct = tuple([collection, new_module])
 
+    try:
+        with db_engines['common'].begin() as conn:
+            id_map = publish_litezip(
+                struct,
+                ('user1', 'test publish',),
+                conn,
+            )
+    except CollectionChanged as err:
+        assert err.collection.id == collection.id
+
+    """FIXME: uncomment.
     with db_engines['common'].begin() as conn:
         id_map = publish_litezip(
             struct,
@@ -55,3 +67,4 @@ def test_publish_litezip(
         .bindparams(moduleid=collection.id, major_version=1, minor_version=2))
     inserted_tree = db_engines['common'].execute(stmt).fetchone()[0]
     compare_legacy_tree_similarity(inserted_tree['contents'], tree)
+    """

--- a/tests/functional/legacy_publishing/test_litezip.py
+++ b/tests/functional/legacy_publishing/test_litezip.py
@@ -37,13 +37,9 @@ def test_publish_litezip(
         )
 
     expected_id_map = {
-        new_module.id: (new_module.id, (2, None)),
         collection.id: (collection.id, (1, 2)),
     }
     assert id_map == expected_id_map
-
-    # Update the tree to reflect the Module publication above.
-    tree[-1].version_at = '1.2'
 
     # Check the collection tree for accuracy. (This is not out of scope,
     # because the collection.xml document needs modified before insertion.)

--- a/tests/functional/views/test_legacy_publishing.py
+++ b/tests/functional/views/test_legacy_publishing.py
@@ -250,6 +250,7 @@ def test_publishing_revision_litezip(
     assert result.submitlog == message
     """
 
+
 def test_publishing_overwrite_module_litezip(
         content_util, persist_util, webapp, db_engines, db_tables):
     webapp.authorization = ('Basic', (a_username, a_passwd))
@@ -264,7 +265,6 @@ def test_publishing_overwrite_module_litezip(
     # Insert a new module ...
     new_module = content_util.gen_module(relative_to=collection)
     new_module = persist_util.insert_module(new_module)
-    new_module_id = new_module.id
 
     # ... remove second element from the tree ...
     tree.pop(1)
@@ -350,7 +350,7 @@ def test_publishing_overwrite_collection_litezip(
     )
     # FIXME: uncomment.
     # assert resp.status_code == 204
-    assert resp.status_code == 400 # no changes to collection.xml
+    assert resp.status_code == 400  # no changes to collection.xml
 
     # Submit a publication, again.
     # Note that this increases the version for new_modules[0] to 1.2
@@ -365,7 +365,7 @@ def test_publishing_overwrite_collection_litezip(
     )
     # FIXME: uncomment.
     # assert resp.status_code == 204
-    assert resp.status_code == 400 # no changes to collection.xml
+    assert resp.status_code == 400  # no changes to collection.xml
 
 
 def test_publishing_no_changes(
@@ -399,6 +399,7 @@ def test_publishing_no_changes(
     # assert resp.status_code == 202
 
     assert resp.status_code == 200
+
 
 def test_publishing_unauthenticated(content_util, persist_util,
                                     webapp, db_engines, db_tables):

--- a/tests/functional/views/test_legacy_publishing.py
+++ b/tests/functional/views/test_legacy_publishing.py
@@ -213,8 +213,11 @@ def test_publishing_revision_litezip(
         '/api/publish-litezip',
         form_data,
         upload_files=file_data,
+        expect_errors=True,
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 400
+
+    """FIXME: uncomment this block of code.
 
     # Check resulting data. (id mapping and urls)
     t = db_tables
@@ -245,7 +248,7 @@ def test_publishing_revision_litezip(
     assert result.version == version
     assert result.submitter == publisher
     assert result.submitlog == message
-
+    """
 
 def test_publishing_overwrite_module_litezip(
         content_util, persist_util, webapp, db_engines, db_tables):
@@ -285,8 +288,11 @@ def test_publishing_overwrite_module_litezip(
         '/api/publish-litezip',
         form_data,
         upload_files=file_data,
+        expect_errors=True,
     )
-    assert resp.status_code == 200
+    # FIXME: uncomment.
+    # assert resp.status_code == 200
+    assert resp.status_code == 400
 
     # Try to submit the publication again (version 1.1)
     with file.open('rb') as fb:
@@ -301,11 +307,10 @@ def test_publishing_overwrite_module_litezip(
     assert resp.status_code == 400
     expected_msgs = [
         {
-            "id": 3,
-            "message": "stale version",
-            "item": new_module_id,
-            "error": "checked out version is 1.1"
-                     " but currently published is 1.2"
+            "id": 4,
+            "message": "collection changed",
+            "item": collection.id,
+            "error": 'modifying a collection is temporarily disallowed'
         }
     ]
     assert resp.json['messages'] == expected_msgs
@@ -341,8 +346,11 @@ def test_publishing_overwrite_collection_litezip(
         '/api/publish-litezip',
         form_data,
         upload_files=file_data,
+        expect_errors=True,
     )
-    assert resp.status_code == 202
+    # FIXME: uncomment.
+    # assert resp.status_code == 204
+    assert resp.status_code == 400 # no changes to collection.xml
 
     # Submit a publication, again.
     # Note that this increases the version for new_modules[0] to 1.2
@@ -353,8 +361,11 @@ def test_publishing_overwrite_collection_litezip(
         '/api/publish-litezip',
         form_data,
         upload_files=file_data,
+        expect_errors=True,
     )
-    assert resp.status_code == 202
+    # FIXME: uncomment.
+    # assert resp.status_code == 204
+    assert resp.status_code == 400 # no changes to collection.xml
 
 
 def test_publishing_no_changes(
@@ -384,8 +395,10 @@ def test_publishing_no_changes(
         form_data,
         upload_files=file_data,
     )
-    assert resp.status_code == 202
+    # FIXME: uncomment
+    # assert resp.status_code == 202
 
+    assert resp.status_code == 200
 
 def test_publishing_unauthenticated(content_util, persist_util,
                                     webapp, db_engines, db_tables):

--- a/tests/functional/views/test_legacy_publishing.py
+++ b/tests/functional/views/test_legacy_publishing.py
@@ -289,7 +289,6 @@ def test_publishing_overwrite_module_litezip(
     assert resp.status_code == 200
 
     # Try to submit the publication again (version 1.1)
-    file = content_util.mk_zipfile_from_litezip_struct(tuple([collection]))
     with file.open('rb') as fb:
         file_data = [('file', 'contents.zip', fb.read(),)]
     form_data = {'publisher': publisher, 'message': message}


### PR DESCRIPTION
NOTE: This PR contains commits that we intend to revert in the future. They contain the words: temporary fix.

This PR initially was intended to address issue https://github.com/Connexions/cnx-press/issues/265 but then we discovered a corner case that prevented us from making it work and reverted the changes until further notice. Now this PR actually enforces a rule that had only been communicated verbally to the content team: do not make any changes to `collection.xml` files.