### PR TITLE
Use the latest image of the cnx-db container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,10 @@ services:
     image: rabbitmq:latest
 
   db:
-    # image: openstax/cnx-db:2.3.0
-    build:
-      context: https://github.com/Connexions/cnx-db.git
-      args:
-        gitcommithash: 731299d
+    image: openstax/cnx-db:latest
+    # For development usage, use something like the following
+    # build:
+    #   context: https://github.com/Connexions/cnx-db.git#master
     ports:
       - "15432:5432"
     environment:


### PR DESCRIPTION
This moves to using the tagged, released, and prebuilt database container.
This should help speed up the testing cycle too, since the image won't
be built on each test run.

See also my comments at https://github.com/Connexions/cnx-db/pull/167#issuecomment-437263856